### PR TITLE
Fix desktop scrolling, progressive sidebar and scroll-to-top UX

### DIFF
--- a/assets/css/scroll-sidebar-ux.css
+++ b/assets/css/scroll-sidebar-ux.css
@@ -27,6 +27,14 @@ html::-webkit-scrollbar-thumb:hover {
   background: var(--accent);
 }
 
+/* `100vw` includes the native scrollbar width on desktop. The existing fixed
+   background already uses inset: 0, so auto width keeps it flush without the
+   16px horizontal overflow and clips its oversized decorative pseudo-elements. */
+.bg-animation {
+  width: auto !important;
+  overflow: hidden;
+}
+
 .main-section {
   scroll-margin-top: 24px;
 }

--- a/assets/css/scroll-sidebar-ux.css
+++ b/assets/css/scroll-sidebar-ux.css
@@ -4,6 +4,12 @@
   --scroll-top-consent-offset: 0px;
 }
 
+html,
+body {
+  max-width: 100%;
+  overflow-x: clip;
+}
+
 html {
   scrollbar-color: var(--ux-scrollbar-thumb) var(--ux-scrollbar-track);
   scrollbar-width: thin;
@@ -29,9 +35,10 @@ html::-webkit-scrollbar-thumb:hover {
 
 /* `100vw` includes the native scrollbar width on desktop. The existing fixed
    background already uses inset: 0, so auto width keeps it flush without the
-   16px horizontal overflow and clips its oversized decorative pseudo-elements. */
+   scrollbar-width overflow and clips its oversized decorative pseudo-elements. */
 .bg-animation {
   width: auto !important;
+  max-width: 100%;
   overflow: hidden;
 }
 
@@ -96,14 +103,22 @@ html::-webkit-scrollbar-thumb:hover {
   }
 
   .container {
+    width: 100%;
+    max-width: 100%;
     height: auto !important;
     min-height: 100vh;
+    margin: 0;
     overflow: visible !important;
   }
 
   .main-content {
+    flex: 0 0 calc(100% - 260px);
+    width: calc(100% - 260px);
+    max-width: calc(100% - 260px);
+    min-width: 0;
     height: auto !important;
     min-height: 100vh;
+    margin-left: 260px;
     overflow: visible !important;
     overscroll-behavior: auto !important;
     scrollbar-gutter: auto !important;

--- a/assets/css/scroll-sidebar-ux.css
+++ b/assets/css/scroll-sidebar-ux.css
@@ -1,0 +1,275 @@
+:root {
+  --ux-scrollbar-track: #151718;
+  --ux-scrollbar-thumb: #686d70;
+  --scroll-top-consent-offset: 0px;
+}
+
+html {
+  scrollbar-color: var(--ux-scrollbar-thumb) var(--ux-scrollbar-track);
+  scrollbar-width: thin;
+}
+
+html::-webkit-scrollbar {
+  width: 10px;
+}
+
+html::-webkit-scrollbar-track {
+  background: var(--ux-scrollbar-track);
+}
+
+html::-webkit-scrollbar-thumb {
+  background: var(--ux-scrollbar-thumb);
+  border: 2px solid var(--ux-scrollbar-track);
+  border-radius: 999px;
+}
+
+html::-webkit-scrollbar-thumb:hover {
+  background: var(--accent);
+}
+
+.main-section {
+  scroll-margin-top: 24px;
+}
+
+.scroll-btn {
+  right: 22px;
+  bottom: calc(24px + var(--scroll-top-consent-offset));
+  width: 48px;
+  height: 48px;
+  padding: 0;
+  color: #17191a;
+  background: var(--accent);
+  border: 2px solid rgba(255, 255, 255, 0.2);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.45), 0 0 0 1px rgba(247, 147, 26, 0.28);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(18px) scale(0.94);
+  pointer-events: none;
+  transition: opacity 180ms ease, visibility 180ms ease, transform 180ms ease, bottom 180ms ease, box-shadow 180ms ease;
+}
+
+.scroll-btn.visible {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.scroll-btn:hover {
+  color: #050606;
+  background: #ffad43;
+  border-color: rgba(255, 255, 255, 0.5);
+  box-shadow: 0 12px 32px rgba(247, 147, 26, 0.42), 0 0 0 3px rgba(247, 147, 26, 0.16);
+}
+
+.scroll-btn:focus-visible {
+  outline: 3px solid #fff;
+  outline-offset: 4px;
+}
+
+.scroll-btn:active {
+  transform: translateY(1px) scale(0.96);
+}
+
+.scroll-btn-icon {
+  width: 25px;
+  height: 25px;
+  display: block;
+  fill: none;
+  stroke: currentcolor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2.5;
+}
+
+@media (min-width: 1025px) {
+  body {
+    overflow-y: auto !important;
+  }
+
+  .container {
+    height: auto !important;
+    min-height: 100vh;
+    overflow: visible !important;
+  }
+
+  .main-content {
+    height: auto !important;
+    min-height: 100vh;
+    overflow: visible !important;
+    overscroll-behavior: auto !important;
+    scrollbar-gutter: auto !important;
+  }
+
+  .sidebar {
+    overflow: hidden;
+    scrollbar-color: var(--ux-scrollbar-thumb) var(--ux-scrollbar-track);
+  }
+
+  .sidebar-info {
+    flex: 1 1 auto;
+    width: 100%;
+    min-height: 0;
+    height: 100%;
+    overflow: hidden;
+  }
+
+  .lang-switch {
+    flex: 0 0 auto;
+  }
+
+  .avatar-bg {
+    max-height: 280px;
+    margin-bottom: 8px;
+    transition: max-height 220ms ease, opacity 180ms ease, margin 220ms ease, padding 220ms ease, transform 220ms ease, border-width 220ms ease;
+  }
+
+  .contacts-list {
+    max-height: 260px;
+    overflow: hidden;
+    transition: max-height 220ms ease, opacity 180ms ease, margin 220ms ease, transform 220ms ease;
+  }
+
+  .sidebar-info > .separator {
+    max-height: 24px;
+    overflow: hidden;
+    transition: max-height 220ms ease, opacity 180ms ease, margin 220ms ease;
+  }
+
+  .navbar {
+    flex: 1 1 auto;
+    width: 100%;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .navbar-list {
+    width: 100%;
+    height: 100%;
+    min-height: 72px;
+    max-height: none !important;
+    overflow-x: hidden;
+    overflow-y: auto;
+    scrollbar-color: var(--ux-scrollbar-thumb) transparent;
+    scrollbar-width: thin;
+  }
+
+  .navbar-list::-webkit-scrollbar {
+    width: 7px;
+  }
+
+  .navbar-list::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .navbar-list::-webkit-scrollbar-thumb {
+    background: var(--ux-scrollbar-thumb);
+    border: 2px solid transparent;
+    border-radius: 999px;
+    background-clip: padding-box;
+  }
+
+  .navbar-list::-webkit-scrollbar-thumb:hover {
+    background: var(--accent);
+    background-clip: padding-box;
+  }
+
+  .navbar-link[aria-current="location"] {
+    color: #111;
+    background: var(--accent);
+    border-color: var(--accent);
+    box-shadow: 0 5px 16px rgba(247, 147, 26, 0.28);
+  }
+
+  body.sidebar-condensed .avatar-bg {
+    max-height: 0;
+    margin: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    border-width: 0;
+    opacity: 0;
+    transform: translateY(-14px) scale(0.92);
+    pointer-events: none;
+  }
+
+  body.sidebar-condensed .contacts-list,
+  body.sidebar-condensed .sidebar-info > .separator {
+    max-height: 0;
+    margin-top: 0;
+    margin-bottom: 0;
+    opacity: 0;
+    transform: translateY(-8px);
+    pointer-events: none;
+  }
+
+  body.sidebar-condensed .main-name {
+    margin: 4px 0 2px;
+    font-size: 1.05rem;
+    line-height: 1.2;
+  }
+
+  body.sidebar-condensed .title {
+    margin: 0 0 10px;
+    font-size: 0.78rem;
+    line-height: 1.35;
+  }
+
+  body.sidebar-condensed .navbar {
+    border-top: 1px solid rgba(247, 147, 26, 0.2);
+    padding-top: 10px;
+  }
+}
+
+@media (min-width: 1025px) and (max-height: 800px) {
+  .sidebar {
+    padding-top: 12px;
+    padding-bottom: 12px;
+  }
+
+  .avatar-bg {
+    max-width: 190px;
+    max-height: 205px;
+    padding: 10px 0;
+  }
+
+  .avatar-box img {
+    width: 148px !important;
+    height: 148px !important;
+  }
+
+  .main-name {
+    font-size: 1.15rem;
+    margin-bottom: 2px;
+  }
+
+  .title {
+    font-size: 0.86rem;
+  }
+
+  .separator {
+    margin: 8px 0;
+  }
+
+  .contact-item {
+    padding-top: 4px;
+    padding-bottom: 4px;
+  }
+}
+
+@media (max-width: 1024px) {
+  .scroll-btn {
+    right: 18px;
+    bottom: calc(20px + var(--scroll-top-consent-offset));
+    width: 46px;
+    height: 46px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scroll-btn,
+  .avatar-bg,
+  .contacts-list,
+  .sidebar-info > .separator {
+    transition: none !important;
+  }
+}

--- a/assets/js/scroll-sidebar-ux.js
+++ b/assets/js/scroll-sidebar-ux.js
@@ -91,6 +91,7 @@ function initializeScrollSidebarUx() {
   let condensed = false;
   let animationFrame = 0;
   let activeSectionId = '';
+  let previousScrollTop = 0;
 
   function updateScrollButtonLabel() {
     if (!scrollButton) return;
@@ -159,20 +160,36 @@ function initializeScrollSidebarUx() {
   function updateActiveSection() {
     if (!sections.length) return;
 
-    const scrollTop = scrollingElement().scrollTop;
-    const viewportAnchor = Math.min(220, window.innerHeight * 0.32);
-    const atDocumentEnd = scrollTop + window.innerHeight >= scrollingElement().scrollHeight - 4;
-    let active = sections[0].id;
+    const scroller = scrollingElement();
+    const scrollTop = scroller.scrollTop;
+    const scrollingDown = scrollTop >= previousScrollTop;
+    previousScrollTop = scrollTop;
+    const atDocumentEnd = scrollTop + window.innerHeight >= scroller.scrollHeight - 4;
 
     if (atDocumentEnd) {
-      active = sections.at(-1).id;
-    } else {
-      sections.forEach(section => {
-        if (section.getBoundingClientRect().top <= viewportAnchor) active = section.id;
-      });
+      setActiveSection(sections.at(-1).id);
+      return;
     }
 
-    setActiveSection(active);
+    const visibleSections = sections
+      .map(section => {
+        const rect = section.getBoundingClientRect();
+        const visibleTop = Math.max(0, rect.top);
+        const visibleBottom = Math.min(window.innerHeight, rect.bottom);
+        return {
+          section,
+          visibleHeight: Math.max(0, visibleBottom - visibleTop)
+        };
+      })
+      .filter(candidate => candidate.visibleHeight >= 16);
+
+    if (!visibleSections.length) return;
+
+    /* When scrolling down, the newly entered lower section is the most useful
+       navigation signal. When scrolling up, prefer the upper visible section.
+       This also handles browser/Playwright nearest-edge scrolling correctly. */
+    const activeCandidate = scrollingDown ? visibleSections.at(-1) : visibleSections[0];
+    setActiveSection(activeCandidate.section.id);
   }
 
   function updateScrollState() {
@@ -234,8 +251,8 @@ function initializeScrollSidebarUx() {
   if ('IntersectionObserver' in window) {
     const observer = new window.IntersectionObserver(requestScrollStateUpdate, {
       root: null,
-      rootMargin: '-15% 0px -65% 0px',
-      threshold: [0, 0.01, 0.25, 0.5]
+      rootMargin: '0px',
+      threshold: [0, 0.01, 0.1, 0.25, 0.5]
     });
     sections.forEach(section => observer.observe(section));
   }

--- a/assets/js/scroll-sidebar-ux.js
+++ b/assets/js/scroll-sidebar-ux.js
@@ -1,0 +1,262 @@
+const SECTION_IDS = [
+  'about',
+  'focus',
+  'skills',
+  'education',
+  'passion',
+  'software',
+  'journey',
+  'projects',
+  'tools',
+  'contact'
+];
+
+const SCROLL_TOP_LABELS = {
+  en: 'Scroll to top',
+  es: 'Volver arriba',
+  ca: 'Tornar a dalt'
+};
+
+const COMPACT_AT = 360;
+const EXPAND_BELOW = 180;
+const SHOW_SCROLL_TOP_AT = 500;
+const DESKTOP_QUERY = '(min-width: 1025px)';
+
+function currentLanguage() {
+  const language = (document.documentElement.lang || 'en').toLowerCase();
+  return Object.hasOwn(SCROLL_TOP_LABELS, language) ? language : 'en';
+}
+
+function setInteractiveState(container, hidden) {
+  if (!container) return;
+
+  container.setAttribute('aria-hidden', hidden ? 'true' : 'false');
+  if ('inert' in container) container.inert = hidden;
+
+  container.querySelectorAll('a, button, input, select, textarea, [tabindex]').forEach(element => {
+    if (hidden) {
+      if (!element.hasAttribute('data-ux-original-tabindex')) {
+        element.setAttribute(
+          'data-ux-original-tabindex',
+          element.hasAttribute('tabindex') ? element.getAttribute('tabindex') : '__none__'
+        );
+      }
+      element.setAttribute('tabindex', '-1');
+      return;
+    }
+
+    const original = element.getAttribute('data-ux-original-tabindex');
+    if (original === '__none__') element.removeAttribute('tabindex');
+    else if (original !== null) element.setAttribute('tabindex', original);
+    element.removeAttribute('data-ux-original-tabindex');
+  });
+}
+
+function initializeScrollSidebarUx() {
+  if (document.documentElement.dataset.scrollSidebarUx === 'ready') return;
+  document.documentElement.dataset.scrollSidebarUx = 'ready';
+
+  const body = document.body;
+  const desktopMedia = window.matchMedia(DESKTOP_QUERY);
+  const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+  const scrollingElement = () => document.scrollingElement || document.documentElement;
+
+  const originalNavList = document.querySelector('.navbar-list');
+  const navList = originalNavList ? originalNavList.cloneNode(true) : null;
+  if (originalNavList && navList) originalNavList.replaceWith(navList);
+
+  const navLinks = navList ? Array.from(navList.querySelectorAll('.navbar-link')) : [];
+  const sections = SECTION_IDS
+    .map(id => document.getElementById(id))
+    .filter(Boolean);
+
+  const originalScrollButton = document.getElementById('scrollTop');
+  const scrollButton = originalScrollButton ? originalScrollButton.cloneNode(false) : null;
+
+  if (originalScrollButton && scrollButton) {
+    originalScrollButton.replaceWith(scrollButton);
+    scrollButton.type = 'button';
+    scrollButton.innerHTML = `
+      <svg class="scroll-btn-icon" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+        <path d="M6 14.5 12 8l6 6.5"></path>
+        <path d="M12 8v10"></path>
+      </svg>
+    `;
+  }
+
+  const avatar = document.querySelector('.avatar-bg');
+  const contacts = document.querySelector('.contacts-list');
+  const separators = Array.from(document.querySelectorAll('.sidebar-info > .separator'));
+  const consent = document.getElementById('consent');
+  let condensed = false;
+  let animationFrame = 0;
+  let activeSectionId = '';
+
+  function updateScrollButtonLabel() {
+    if (!scrollButton) return;
+    const label = SCROLL_TOP_LABELS[currentLanguage()];
+    scrollButton.setAttribute('aria-label', label);
+    scrollButton.setAttribute('title', label);
+  }
+
+  function updateConsentOffset() {
+    let offset = 0;
+
+    if (consent && consent.isConnected && !consent.hidden) {
+      const style = window.getComputedStyle(consent);
+      const rect = consent.getBoundingClientRect();
+      if (style.display !== 'none' && style.visibility !== 'hidden' && rect.height > 0) {
+        offset = Math.max(0, window.innerHeight - rect.top + 12);
+      }
+    }
+
+    document.documentElement.style.setProperty('--scroll-top-consent-offset', `${Math.ceil(offset)}px`);
+  }
+
+  function setCondensed(nextCondensed) {
+    const next = desktopMedia.matches && nextCondensed;
+    if (next === condensed && contacts?.getAttribute('aria-hidden') !== null) return;
+
+    condensed = next;
+    body.classList.toggle('sidebar-condensed', condensed);
+    setInteractiveState(contacts, condensed);
+
+    if (avatar) avatar.setAttribute('aria-hidden', condensed ? 'true' : 'false');
+    separators.forEach(separator => separator.setAttribute('aria-hidden', condensed ? 'true' : 'false'));
+  }
+
+  function setScrollButtonVisible(visible) {
+    if (!scrollButton) return;
+    scrollButton.classList.toggle('visible', visible);
+    scrollButton.setAttribute('aria-hidden', visible ? 'false' : 'true');
+    scrollButton.setAttribute('tabindex', visible ? '0' : '-1');
+  }
+
+  function keepActiveLinkVisible(link) {
+    if (!navList || !link || !desktopMedia.matches) return;
+    const navRect = navList.getBoundingClientRect();
+    const linkRect = link.getBoundingClientRect();
+
+    if (linkRect.top < navRect.top || linkRect.bottom > navRect.bottom) {
+      link.scrollIntoView({ block: 'nearest', inline: 'nearest', behavior: 'auto' });
+    }
+  }
+
+  function setActiveSection(sectionId) {
+    if (!sectionId || sectionId === activeSectionId) return;
+    activeSectionId = sectionId;
+
+    navLinks.forEach(link => {
+      const active = link.getAttribute('href') === `#${sectionId}`;
+      link.classList.toggle('active', active);
+      if (active) link.setAttribute('aria-current', 'location');
+      else link.removeAttribute('aria-current');
+    });
+
+    keepActiveLinkVisible(navLinks.find(link => link.getAttribute('href') === `#${sectionId}`));
+  }
+
+  function updateActiveSection() {
+    if (!sections.length) return;
+
+    const scrollTop = scrollingElement().scrollTop;
+    const viewportAnchor = Math.min(220, window.innerHeight * 0.32);
+    const atDocumentEnd = scrollTop + window.innerHeight >= scrollingElement().scrollHeight - 4;
+    let active = sections[0].id;
+
+    if (atDocumentEnd) {
+      active = sections.at(-1).id;
+    } else {
+      sections.forEach(section => {
+        if (section.getBoundingClientRect().top <= viewportAnchor) active = section.id;
+      });
+    }
+
+    setActiveSection(active);
+  }
+
+  function updateScrollState() {
+    animationFrame = 0;
+    const scrollTop = scrollingElement().scrollTop;
+
+    if (!desktopMedia.matches) setCondensed(false);
+    else if (!condensed && scrollTop >= COMPACT_AT) setCondensed(true);
+    else if (condensed && scrollTop <= EXPAND_BELOW) setCondensed(false);
+
+    setScrollButtonVisible(scrollTop >= SHOW_SCROLL_TOP_AT);
+    updateConsentOffset();
+    updateActiveSection();
+  }
+
+  function requestScrollStateUpdate() {
+    if (!animationFrame) animationFrame = window.requestAnimationFrame(updateScrollState);
+  }
+
+  navLinks.forEach(link => {
+    link.addEventListener('click', () => {
+      const sectionId = link.getAttribute('href')?.slice(1);
+      if (sectionId) setActiveSection(sectionId);
+    });
+  });
+
+  if (scrollButton) {
+    scrollButton.addEventListener('click', () => {
+      window.scrollTo({
+        top: 0,
+        behavior: reduceMotion.matches ? 'auto' : 'smooth'
+      });
+    });
+  }
+
+  document.querySelector('.lang-switch')?.addEventListener('click', event => {
+    if (!event.target.closest('button[data-lang]')) return;
+    window.requestAnimationFrame(updateScrollButtonLabel);
+  });
+
+  new MutationObserver(updateScrollButtonLabel).observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['lang']
+  });
+
+  if (consent) {
+    new MutationObserver(updateConsentOffset).observe(consent, {
+      attributes: true,
+      attributeFilter: ['hidden', 'style', 'class']
+    });
+    if ('ResizeObserver' in window) new ResizeObserver(updateConsentOffset).observe(consent);
+  }
+
+  new MutationObserver(updateConsentOffset).observe(document.body, {
+    childList: true,
+    subtree: true
+  });
+
+  if ('IntersectionObserver' in window) {
+    const observer = new IntersectionObserver(requestScrollStateUpdate, {
+      root: null,
+      rootMargin: '-15% 0px -65% 0px',
+      threshold: [0, 0.01, 0.25, 0.5]
+    });
+    sections.forEach(section => observer.observe(section));
+  }
+
+  window.addEventListener('scroll', requestScrollStateUpdate, { passive: true });
+  window.addEventListener('resize', requestScrollStateUpdate, { passive: true });
+  desktopMedia.addEventListener('change', requestScrollStateUpdate);
+  reduceMotion.addEventListener('change', requestScrollStateUpdate);
+
+  updateScrollButtonLabel();
+  setInteractiveState(contacts, false);
+  setScrollButtonVisible(false);
+  updateScrollState();
+}
+
+function scheduleInitialization() {
+  window.queueMicrotask(initializeScrollSidebarUx);
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', scheduleInitialization, { once: true });
+} else {
+  scheduleInitialization();
+}

--- a/assets/js/scroll-sidebar-ux.js
+++ b/assets/js/scroll-sidebar-ux.js
@@ -91,7 +91,6 @@ function initializeScrollSidebarUx() {
   let condensed = false;
   let animationFrame = 0;
   let activeSectionId = '';
-  let previousScrollTop = 0;
 
   function updateScrollButtonLabel() {
     if (!scrollButton) return;
@@ -162,34 +161,42 @@ function initializeScrollSidebarUx() {
 
     const scroller = scrollingElement();
     const scrollTop = scroller.scrollTop;
-    const scrollingDown = scrollTop >= previousScrollTop;
-    previousScrollTop = scrollTop;
     const atDocumentEnd = scrollTop + window.innerHeight >= scroller.scrollHeight - 4;
+
+    if (scrollTop <= 2) {
+      setActiveSection(sections[0].id);
+      return;
+    }
 
     if (atDocumentEnd) {
       setActiveSection(sections.at(-1).id);
       return;
     }
 
-    const visibleSections = sections
+    /* A stable reading line avoids direction-dependent oscillation and makes
+       mouse, keyboard, scrollbar and programmatic scrolling resolve identically. */
+    const readingLine = Math.min(Math.max(window.innerHeight * 0.35, 96), 260);
+    const containingSection = sections.find(section => {
+      const rect = section.getBoundingClientRect();
+      return rect.top <= readingLine && rect.bottom > readingLine;
+    });
+
+    if (containingSection) {
+      setActiveSection(containingSection.id);
+      return;
+    }
+
+    const nearestSection = sections
       .map(section => {
         const rect = section.getBoundingClientRect();
-        const visibleTop = Math.max(0, rect.top);
-        const visibleBottom = Math.min(window.innerHeight, rect.bottom);
-        return {
-          section,
-          visibleHeight: Math.max(0, visibleBottom - visibleTop)
-        };
+        const distance = rect.bottom < readingLine
+          ? readingLine - rect.bottom
+          : rect.top - readingLine;
+        return { section, distance: Math.max(0, distance) };
       })
-      .filter(candidate => candidate.visibleHeight >= 16);
+      .sort((first, second) => first.distance - second.distance)[0]?.section;
 
-    if (!visibleSections.length) return;
-
-    /* When scrolling down, the newly entered lower section is the most useful
-       navigation signal. When scrolling up, prefer the upper visible section.
-       This also handles browser/Playwright nearest-edge scrolling correctly. */
-    const activeCandidate = scrollingDown ? visibleSections.at(-1) : visibleSections[0];
-    setActiveSection(activeCandidate.section.id);
+    if (nearestSection) setActiveSection(nearestSection.id);
   }
 
   function updateScrollState() {
@@ -213,6 +220,7 @@ function initializeScrollSidebarUx() {
     link.addEventListener('click', () => {
       const sectionId = link.getAttribute('href')?.slice(1);
       if (sectionId) setActiveSection(sectionId);
+      window.requestAnimationFrame(requestScrollStateUpdate);
     });
   });
 
@@ -227,7 +235,10 @@ function initializeScrollSidebarUx() {
 
   document.querySelector('.lang-switch')?.addEventListener('click', event => {
     if (!event.target.closest('button[data-lang]')) return;
-    window.requestAnimationFrame(updateScrollButtonLabel);
+    window.requestAnimationFrame(() => {
+      updateScrollButtonLabel();
+      requestScrollStateUpdate();
+    });
   });
 
   new window.MutationObserver(updateScrollButtonLabel).observe(document.documentElement, {
@@ -251,14 +262,15 @@ function initializeScrollSidebarUx() {
   if ('IntersectionObserver' in window) {
     const observer = new window.IntersectionObserver(requestScrollStateUpdate, {
       root: null,
-      rootMargin: '0px',
-      threshold: [0, 0.01, 0.1, 0.25, 0.5]
+      rootMargin: '-20% 0px -55% 0px',
+      threshold: [0, 0.01, 0.25, 0.5]
     });
     sections.forEach(section => observer.observe(section));
   }
 
   window.addEventListener('scroll', requestScrollStateUpdate, { passive: true });
   window.addEventListener('resize', requestScrollStateUpdate, { passive: true });
+  window.addEventListener('hashchange', requestScrollStateUpdate);
   desktopMedia.addEventListener('change', requestScrollStateUpdate);
   reduceMotion.addEventListener('change', requestScrollStateUpdate);
 

--- a/assets/js/scroll-sidebar-ux.js
+++ b/assets/js/scroll-sidebar-ux.js
@@ -213,26 +213,26 @@ function initializeScrollSidebarUx() {
     window.requestAnimationFrame(updateScrollButtonLabel);
   });
 
-  new MutationObserver(updateScrollButtonLabel).observe(document.documentElement, {
+  new window.MutationObserver(updateScrollButtonLabel).observe(document.documentElement, {
     attributes: true,
     attributeFilter: ['lang']
   });
 
   if (consent) {
-    new MutationObserver(updateConsentOffset).observe(consent, {
+    new window.MutationObserver(updateConsentOffset).observe(consent, {
       attributes: true,
       attributeFilter: ['hidden', 'style', 'class']
     });
-    if ('ResizeObserver' in window) new ResizeObserver(updateConsentOffset).observe(consent);
+    if ('ResizeObserver' in window) new window.ResizeObserver(updateConsentOffset).observe(consent);
   }
 
-  new MutationObserver(updateConsentOffset).observe(document.body, {
+  new window.MutationObserver(updateConsentOffset).observe(document.body, {
     childList: true,
     subtree: true
   });
 
   if ('IntersectionObserver' in window) {
-    const observer = new IntersectionObserver(requestScrollStateUpdate, {
+    const observer = new window.IntersectionObserver(requestScrollStateUpdate, {
       root: null,
       rootMargin: '-15% 0px -65% 0px',
       threshold: [0, 0.01, 0.25, 0.5]

--- a/tests/scroll-sidebar-ux.spec.js
+++ b/tests/scroll-sidebar-ux.spec.js
@@ -1,0 +1,148 @@
+import { test, expect } from '@playwright/test';
+import { openHome } from './helpers';
+
+const sectionIds = ['about', 'focus', 'skills', 'education', 'passion', 'software', 'journey', 'projects', 'tools', 'contact'];
+const languageLabels = {
+  en: 'Scroll to top',
+  es: 'Volver arriba',
+  ca: 'Tornar a dalt'
+};
+
+async function stablePage(page, viewport = { width: 1366, height: 768 }) {
+  await page.setViewportSize(viewport);
+  await page.addInitScript(() => localStorage.clear());
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  const guard = await openHome(page);
+  await page.evaluate(() => document.documentElement.classList.add('qa-stable'));
+  return guard;
+}
+
+async function scrollToSection(page, id) {
+  await page.locator(`#${id}`).scrollIntoViewIfNeeded();
+  await page.waitForFunction(
+    targetId => document.querySelector(`.navbar-link[href="#${targetId}"]`)?.getAttribute('aria-current') === 'location',
+    id
+  );
+}
+
+test('document owns desktop scrolling without horizontal overflow', async ({ page }) => {
+  const guard = await stablePage(page);
+
+  const initial = await page.evaluate(() => ({
+    scrollingElement: document.scrollingElement?.tagName,
+    scrollY: window.scrollY,
+    mainClientHeight: document.querySelector('.main-content')?.clientHeight,
+    mainScrollHeight: document.querySelector('.main-content')?.scrollHeight,
+    mainOverflowY: window.getComputedStyle(document.querySelector('.main-content')).overflowY,
+    containerClientHeight: document.querySelector('.container')?.clientHeight,
+    containerScrollHeight: document.querySelector('.container')?.scrollHeight,
+    containerOverflowY: window.getComputedStyle(document.querySelector('.container')).overflowY,
+    horizontalOverflow: document.documentElement.scrollWidth - document.documentElement.clientWidth
+  }));
+
+  expect(initial.scrollingElement).toBe('HTML');
+  expect(initial.mainOverflowY).not.toBe('auto');
+  expect(initial.containerOverflowY).not.toBe('auto');
+  expect(initial.horizontalOverflow).toBeLessThanOrEqual(2);
+  expect(initial.mainScrollHeight - initial.mainClientHeight).toBeLessThanOrEqual(2);
+  expect(initial.containerScrollHeight - initial.containerClientHeight).toBeLessThanOrEqual(2);
+
+  await page.mouse.wheel(0, 900);
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(initial.scrollY);
+  guard.assertNoSameOriginFailures();
+});
+
+test('scroll-to-top is translated, visible after threshold, keyboard accessible and avoids consent', async ({ page }) => {
+  const guard = await stablePage(page);
+  const scrollTop = page.locator('#scrollTop');
+
+  await expect(scrollTop).toBeHidden();
+  await expect(scrollTop).toHaveAttribute('tabindex', '-1');
+  await page.evaluate(() => window.scrollTo(0, 520));
+  await expect(scrollTop).toBeVisible();
+  await expect(scrollTop.locator('svg.scroll-btn-icon')).toBeVisible();
+  await expect(scrollTop.locator('ion-icon')).toHaveCount(0);
+
+  const overlap = await page.evaluate(() => {
+    const button = document.getElementById('scrollTop').getBoundingClientRect();
+    const consent = document.getElementById('consent').getBoundingClientRect();
+    const width = Math.max(0, Math.min(button.right, consent.right) - Math.max(button.left, consent.left));
+    const height = Math.max(0, Math.min(button.bottom, consent.bottom) - Math.max(button.top, consent.top));
+    return width * height;
+  });
+  expect(overlap).toBe(0);
+
+  for (const [lang, label] of Object.entries(languageLabels)) {
+    await page.locator(`button[data-lang="${lang}"]`).click();
+    await expect(scrollTop).toHaveAttribute('aria-label', label);
+    await expect(scrollTop).toHaveAttribute('title', label);
+  }
+
+  await scrollTop.click();
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeLessThan(5);
+  await expect(scrollTop).toBeHidden();
+
+  await page.evaluate(() => window.scrollTo(0, 620));
+  await expect(scrollTop).toBeVisible();
+  await scrollTop.focus();
+  await page.keyboard.press('Enter');
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeLessThan(5);
+  guard.assertNoSameOriginFailures();
+});
+
+for (const height of [650, 768]) {
+  test(`progressive sidebar uses hysteresis and preserves useful nav at 1366x${height}`, async ({ page }) => {
+    const guard = await stablePage(page, { width: 1366, height });
+    const avatar = page.locator('.avatar-bg');
+    const contacts = page.locator('.contacts-list');
+    const identity = page.locator('.main-name');
+    const navList = page.locator('.navbar-list');
+
+    await expect(avatar).toBeVisible();
+    await expect(contacts).toBeVisible();
+    await expect(identity).toBeVisible();
+    await expect(navList).toBeVisible();
+    const expandedNavHeight = await navList.evaluate(element => element.getBoundingClientRect().height);
+
+    await page.evaluate(() => window.scrollTo(0, 370));
+    await expect(page.locator('body')).toHaveClass(/sidebar-condensed/);
+    await expect(identity).toBeVisible();
+    await expect(contacts).toHaveAttribute('aria-hidden', 'true');
+    await expect(contacts.locator('a').first()).toHaveAttribute('tabindex', '-1');
+    const compactNavHeight = await navList.evaluate(element => element.getBoundingClientRect().height);
+    expect(compactNavHeight).toBeGreaterThan(expandedNavHeight);
+
+    await page.evaluate(() => window.scrollTo(0, 240));
+    await expect(page.locator('body')).toHaveClass(/sidebar-condensed/);
+    await page.evaluate(() => window.scrollTo(0, 170));
+    await expect(page.locator('body')).not.toHaveClass(/sidebar-condensed/);
+    await expect(contacts).toHaveAttribute('aria-hidden', 'false');
+    await expect(contacts.locator('a').first()).not.toHaveAttribute('tabindex', '-1');
+    guard.assertNoSameOriginFailures();
+  });
+}
+
+for (const lang of ['en', 'es', 'ca']) {
+  test(`scrollspy keeps Projects, Tools and Contact active and visible in ${lang}`, async ({ page }) => {
+    const guard = await stablePage(page);
+    await page.locator(`button[data-lang="${lang}"]`).click();
+
+    for (const id of ['projects', 'tools', 'contact']) {
+      await scrollToSection(page, id);
+      const link = page.locator(`.navbar-link[href="#${id}"]`);
+      await expect(link).toHaveAttribute('aria-current', 'location');
+      await expect(link).toBeInViewport();
+      const navContainsActive = await page.evaluate(targetId => {
+        const nav = document.querySelector('.navbar-list').getBoundingClientRect();
+        const active = document.querySelector(`.navbar-link[href="#${targetId}"]`).getBoundingClientRect();
+        return active.top >= nav.top - 1 && active.bottom <= nav.bottom + 1;
+      }, id);
+      expect(navContainsActive).toBe(true);
+    }
+
+    expect(await page.locator('.navbar-link').evaluateAll(links => links.map(link => link.getAttribute('href')))).toEqual(
+      sectionIds.map(id => `#${id}`)
+    );
+    guard.assertNoSameOriginFailures();
+  });
+}

--- a/tests/scroll-sidebar-ux.spec.js
+++ b/tests/scroll-sidebar-ux.spec.js
@@ -28,24 +28,35 @@ async function scrollToSection(page, id) {
 test('document owns desktop scrolling without horizontal overflow', async ({ page }) => {
   const guard = await stablePage(page);
 
-  const initial = await page.evaluate(() => ({
-    scrollingElement: document.scrollingElement?.tagName,
-    scrollY: window.scrollY,
-    mainClientHeight: document.querySelector('.main-content')?.clientHeight,
-    mainScrollHeight: document.querySelector('.main-content')?.scrollHeight,
-    mainOverflowY: window.getComputedStyle(document.querySelector('.main-content')).overflowY,
-    containerClientHeight: document.querySelector('.container')?.clientHeight,
-    containerScrollHeight: document.querySelector('.container')?.scrollHeight,
-    containerOverflowY: window.getComputedStyle(document.querySelector('.container')).overflowY,
-    horizontalOverflow: document.documentElement.scrollWidth - document.documentElement.clientWidth
-  }));
+  const initial = await page.evaluate(() => {
+    const probeScrollOwnership = selector => {
+      const element = document.querySelector(selector);
+      const originalScrollTop = element.scrollTop;
+      element.scrollTop = 100;
+      const retainedScrollTop = element.scrollTop;
+      element.scrollTop = originalScrollTop;
+
+      return {
+        overflowY: window.getComputedStyle(element).overflowY,
+        retainedScrollTop
+      };
+    };
+
+    return {
+      scrollingElement: document.scrollingElement?.tagName,
+      scrollY: window.scrollY,
+      main: probeScrollOwnership('.main-content'),
+      container: probeScrollOwnership('.container'),
+      horizontalOverflow: document.documentElement.scrollWidth - document.documentElement.clientWidth
+    };
+  });
 
   expect(initial.scrollingElement).toBe('HTML');
-  expect(initial.mainOverflowY).not.toBe('auto');
-  expect(initial.containerOverflowY).not.toBe('auto');
+  expect(['auto', 'scroll', 'overlay']).not.toContain(initial.main.overflowY);
+  expect(['auto', 'scroll', 'overlay']).not.toContain(initial.container.overflowY);
+  expect(initial.main.retainedScrollTop).toBe(0);
+  expect(initial.container.retainedScrollTop).toBe(0);
   expect(initial.horizontalOverflow).toBeLessThanOrEqual(2);
-  expect(initial.mainScrollHeight - initial.mainClientHeight).toBeLessThanOrEqual(2);
-  expect(initial.containerScrollHeight - initial.containerClientHeight).toBeLessThanOrEqual(2);
 
   await page.mouse.wheel(0, 900);
   await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(initial.scrollY);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,9 +10,18 @@ const hardenGeneratedHtml = {
       "script-src 'self' https://unpkg.com https://cdn.jsdelivr.net https://plausible.io;"
     );
 
-    return withPlausibleCsp.replace(
+    const withUxStyles = withPlausibleCsp.replace(
       '</head>',
-      '  <link rel="stylesheet" href="./assets/css/qa-fixes.css">\n</head>'
+      [
+        '  <link rel="stylesheet" href="./assets/css/qa-fixes.css">',
+        '  <link rel="stylesheet" href="./assets/css/scroll-sidebar-ux.css">',
+        '</head>'
+      ].join('\n')
+    );
+
+    return withUxStyles.replace(
+      '</body>',
+      '  <script type="module" src="./assets/js/scroll-sidebar-ux.js"></script>\n</body>'
     );
   }
 };


### PR DESCRIPTION
## Motivation

Desktop visitors currently see the primary scrollbar inside the content pane, an ambiguous scroll-to-top control, and a sidebar whose section navigation becomes too small on short-height screens.

## Changes

- Restore document-owned scrolling so the browser scrollbar sits at the far-right viewport edge.
- Add a progressive desktop sidebar with 360 px collapse and 180 px expansion hysteresis.
- Keep compact identity and language controls visible while expanding the section navigator.
- Make collapsed contact links inaccessible to keyboard and assistive technology.
- Add IntersectionObserver-based scrollspy with `aria-current="location"`.
- Replace the external icon dependency in the scroll-to-top control with an inline SVG arrow.
- Add EN/ES/CA accessible labels and reduced-motion support.
- Dynamically offset the button above the visible consent banner.
- Add focused Playwright regression coverage for document scrolling, sidebar state, scrollspy, translations, keyboard activation and consent overlap.

## Implementation note

The UX is isolated in dedicated CSS and JavaScript assets loaded by Vite after the existing application assets. Existing listeners are safely detached from the affected scroll button and navigation list by cloning those two DOM nodes after initialization, avoiding invasive rewrites of the established application scripts.

## Validation

GitHub Actions must validate lint, build, generated references, privacy, Chromium Playwright, Axe and the existing EN/ES/CA responsive matrix before merge.

The pull request must remain unmerged until the complete QA job is green.