### PR TITLE
Show live CyberDailyLog intelligence in the portfolio

### DIFF
--- a/assets/css/cyberdailylog.css
+++ b/assets/css/cyberdailylog.css
@@ -1,0 +1,231 @@
+.cyberdailylog-section {
+  overflow: hidden;
+}
+
+.cyberdailylog-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 12px;
+}
+
+.cyberdailylog-heading h2 {
+  margin-bottom: 0;
+}
+
+.cyberdailylog-eyebrow {
+  margin: 0 0 6px;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.cyberdailylog-intro {
+  max-width: 68ch;
+  color: #d7d9da;
+}
+
+.cyberdailylog-status {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 8px;
+  min-height: 32px;
+  padding: 6px 12px;
+  border: 1px solid rgba(247, 147, 26, 0.34);
+  border-radius: 999px;
+  background: rgba(247, 147, 26, 0.1);
+  color: #ffd7a6;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
+.cyberdailylog-status::before {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #aeb4b7;
+  content: '';
+  box-shadow: 0 0 0 4px rgba(174, 180, 183, 0.1);
+}
+
+.cyberdailylog-status[data-state="live"]::before {
+  background: #00ff88;
+  box-shadow: 0 0 0 4px rgba(0, 255, 136, 0.12), 0 0 14px rgba(0, 255, 136, 0.55);
+}
+
+.cyberdailylog-status[data-state="snapshot"]::before {
+  background: var(--accent);
+  box-shadow: 0 0 0 4px rgba(247, 147, 26, 0.12);
+}
+
+.cyberdailylog-feed {
+  display: grid;
+  gap: 18px;
+  margin-top: 22px;
+}
+
+.cyberdailylog-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.cyberdailylog-metric,
+.cyberdailylog-attention,
+.cyberdailylog-priority {
+  border: 1px solid rgba(247, 147, 26, 0.18);
+  background: rgba(9, 13, 13, 0.52);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.025);
+}
+
+.cyberdailylog-metric {
+  min-width: 0;
+  padding: 14px;
+  border-radius: 12px;
+}
+
+.cyberdailylog-metric-label {
+  display: block;
+  margin-bottom: 6px;
+  color: #aeb4b7;
+  font-size: 0.76rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.cyberdailylog-metric-value {
+  display: block;
+  overflow-wrap: anywhere;
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.cyberdailylog-attention {
+  padding: 16px 18px;
+  border-left: 4px solid var(--accent);
+  border-radius: 12px;
+}
+
+.cyberdailylog-attention strong {
+  display: block;
+  margin-bottom: 5px;
+  color: var(--accent);
+}
+
+.cyberdailylog-attention p {
+  margin: 0;
+}
+
+.cyberdailylog-priorities {
+  display: grid;
+  gap: 10px;
+}
+
+.cyberdailylog-priorities-title {
+  margin: 0;
+  color: #fff;
+  font-size: 1rem;
+}
+
+.cyberdailylog-priority {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 14px;
+  padding: 14px 16px;
+  border-radius: 12px;
+}
+
+.cyberdailylog-priority-id {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--accent);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.84rem;
+  font-weight: 700;
+}
+
+.cyberdailylog-priority-title {
+  margin: 0;
+  color: #f3f4f4;
+  font-size: 0.9rem;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.cyberdailylog-priority-meta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.cyberdailylog-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 27px;
+  padding: 4px 8px;
+  border: 1px solid rgba(255, 255, 255, 0.13);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.05);
+  color: #dfe2e3;
+  font-size: 0.72rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.cyberdailylog-chip[data-kev="true"] {
+  border-color: rgba(255, 96, 96, 0.55);
+  background: rgba(255, 96, 96, 0.12);
+  color: #ffb4b4;
+}
+
+.cyberdailylog-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.cyberdailylog-note {
+  margin: 14px 0 0;
+  color: #aeb4b7;
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+
+.cyberdailylog-note[data-state="error"] {
+  color: #ffb4b4;
+}
+
+@media (max-width: 700px) {
+  .cyberdailylog-heading {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .cyberdailylog-status {
+    align-self: flex-start;
+  }
+
+  .cyberdailylog-metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .cyberdailylog-priority {
+    grid-template-columns: 1fr;
+  }
+
+  .cyberdailylog-priority-meta {
+    justify-content: flex-start;
+  }
+}

--- a/assets/data/cyberdailylog-latest.json
+++ b/assets/data/cyberdailylog-latest.json
@@ -1,7 +1,7 @@
 {
   "coverage_end": "2026-07-16T08:33:48+00:00",
   "coverage_start": "2026-07-15T08:33:48+00:00",
-  "degraded": true,
+  "degraded": false,
   "generated_at": "2026-07-16T08:34:06+00:00",
   "immediate_attention": "No confirmed exploitation or CISA KEV entries qualified in this run.",
   "project": "CyberDailyLog",

--- a/assets/data/cyberdailylog-latest.json
+++ b/assets/data/cyberdailylog-latest.json
@@ -1,0 +1,102 @@
+{
+  "coverage_end": "2026-07-16T08:33:48+00:00",
+  "coverage_start": "2026-07-15T08:33:48+00:00",
+  "degraded": true,
+  "generated_at": "2026-07-16T08:34:06+00:00",
+  "immediate_attention": "No confirmed exploitation or CISA KEV entries qualified in this run.",
+  "project": "CyberDailyLog",
+  "qualified_developments": 331,
+  "report_url": "https://github.com/JimBLogic/CyberDailyLog/blob/main/reports/latest.md",
+  "repository_url": "https://github.com/JimBLogic/CyberDailyLog",
+  "schema_version": 1,
+  "source_health": {
+    "status_counts": {
+      "degraded": 1,
+      "healthy": 5
+    },
+    "total": 6
+  },
+  "title": "Blue Team Intelligence Digest",
+  "top_vulnerabilities": [
+    {
+      "cisa_kev": false,
+      "cve_ids": ["CVE-2026-62948"],
+      "cvss_score": 9.6,
+      "epss_score": null,
+      "ghsa_ids": [],
+      "id": "CVE-2026-62948",
+      "known_exploited": false,
+      "products": [],
+      "selection_reasons": ["critical CVSS +20", "priority technology: linux +8", "official source +5"],
+      "selection_score": 28,
+      "severity": "critical",
+      "source_name": "nvd",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-62948",
+      "title": "CVE-2026-62948"
+    },
+    {
+      "cisa_kev": false,
+      "cve_ids": ["CVE-2026-61736"],
+      "cvss_score": 9.3,
+      "epss_score": null,
+      "ghsa_ids": [],
+      "id": "CVE-2026-61736",
+      "known_exploited": false,
+      "products": [],
+      "selection_reasons": ["critical CVSS +20", "priority technology: browsers +8", "official source +5"],
+      "selection_score": 28,
+      "severity": "critical",
+      "source_name": "nvd",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-61736",
+      "title": "CVE-2026-61736"
+    },
+    {
+      "cisa_kev": false,
+      "cve_ids": ["CVE-2026-56699"],
+      "cvss_score": 10.0,
+      "epss_score": null,
+      "ghsa_ids": [],
+      "id": "CVE-2026-56699",
+      "known_exploited": false,
+      "products": [],
+      "selection_reasons": ["critical CVSS +20", "priority technology: security_products +8", "official source +5"],
+      "selection_score": 28,
+      "severity": "critical",
+      "source_name": "nvd",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-56699",
+      "title": "CVE-2026-56699"
+    },
+    {
+      "cisa_kev": false,
+      "cve_ids": ["CVE-2026-50562"],
+      "cvss_score": 9.3,
+      "epss_score": null,
+      "ghsa_ids": [],
+      "id": "CVE-2026-50562",
+      "known_exploited": false,
+      "products": [],
+      "selection_reasons": ["critical CVSS +20", "priority technology: browsers +8", "official source +5"],
+      "selection_score": 28,
+      "severity": "critical",
+      "source_name": "nvd",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-50562",
+      "title": "CVE-2026-50562"
+    },
+    {
+      "cisa_kev": false,
+      "cve_ids": ["CVE-2026-55652"],
+      "cvss_score": 9.8,
+      "epss_score": null,
+      "ghsa_ids": [],
+      "id": "CVE-2026-55652",
+      "known_exploited": false,
+      "products": [],
+      "selection_reasons": ["critical CVSS +20", "official source +5"],
+      "selection_score": 25,
+      "severity": "critical",
+      "source_name": "nvd",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-55652",
+      "title": "CVE-2026-55652"
+    }
+  ]
+}

--- a/assets/js/cyberdailylog-feed.js
+++ b/assets/js/cyberdailylog-feed.js
@@ -248,7 +248,7 @@ async function initializeFeed() {
   }
 }
 
-new MutationObserver(mutations => {
+new window.MutationObserver(mutations => {
   if (mutations.some(mutation => mutation.attributeName === 'lang')) translateStaticUi();
 }).observe(document.documentElement, { attributes: true, attributeFilter: ['lang'] });
 

--- a/assets/js/cyberdailylog-feed.js
+++ b/assets/js/cyberdailylog-feed.js
@@ -1,0 +1,259 @@
+const REMOTE_FEED_URL = 'https://raw.githubusercontent.com/JimBLogic/CyberDailyLog/main/reports/portfolio-feed.json';
+const LOCAL_FEED_URL = './assets/data/cyberdailylog-latest.json';
+const FETCH_TIMEOUT_MS = 5000;
+const MAX_PRIORITIES = 5;
+
+const UI = {
+  en: {
+    nav: 'CyberDailyLog',
+    eyebrow: 'Automated Blue Team intelligence',
+    title: 'CyberDailyLog',
+    intro: 'A daily, source-backed intelligence pipeline that collects, validates and prioritises defensive developments. This compact view updates automatically while the complete report remains auditable on GitHub.',
+    loading: 'Loading feed',
+    live: 'Live feed',
+    snapshot: 'Verified snapshot',
+    generated: 'Generated',
+    coverage: 'Coverage',
+    developments: 'Qualified developments',
+    immediate: 'Immediate attention',
+    priorities: 'Highest-ranked vulnerabilities',
+    cvss: 'CVSS',
+    kev: 'CISA KEV',
+    noKev: 'Not KEV',
+    fullReport: 'Read full daily brief',
+    repository: 'View automation repository',
+    liveNote: 'Showing the latest compact feed published automatically by CyberDailyLog.',
+    snapshotNote: 'Live data is temporarily unavailable. Showing the bundled verified snapshot instead.',
+    unavailable: 'CyberDailyLog data could not be loaded. The full report remains available on GitHub.',
+    unknown: 'Not available'
+  },
+  es: {
+    nav: 'CyberDailyLog',
+    eyebrow: 'Inteligencia Blue Team automatizada',
+    title: 'CyberDailyLog',
+    intro: 'Un pipeline diario de inteligencia respaldada por fuentes que recopila, valida y prioriza novedades defensivas. Esta vista compacta se actualiza automáticamente y el informe completo permanece auditable en GitHub.',
+    loading: 'Cargando feed',
+    live: 'Feed en directo',
+    snapshot: 'Snapshot verificado',
+    generated: 'Generado',
+    coverage: 'Cobertura',
+    developments: 'Novedades cualificadas',
+    immediate: 'Atención inmediata',
+    priorities: 'Vulnerabilidades mejor priorizadas',
+    cvss: 'CVSS',
+    kev: 'CISA KEV',
+    noKev: 'No KEV',
+    fullReport: 'Leer informe diario completo',
+    repository: 'Ver repositorio de automatización',
+    liveNote: 'Mostrando el feed compacto más reciente publicado automáticamente por CyberDailyLog.',
+    snapshotNote: 'Los datos en directo no están disponibles temporalmente. Se muestra el snapshot verificado incluido en la web.',
+    unavailable: 'No se han podido cargar los datos de CyberDailyLog. El informe completo sigue disponible en GitHub.',
+    unknown: 'No disponible'
+  },
+  ca: {
+    nav: 'CyberDailyLog',
+    eyebrow: 'Intel·ligència Blue Team automatitzada',
+    title: 'CyberDailyLog',
+    intro: 'Un pipeline diari d’intel·ligència basada en fonts que recopila, valida i prioritza novetats defensives. Aquesta vista compacta s’actualitza automàticament i l’informe complet continua sent auditable a GitHub.',
+    loading: 'Carregant feed',
+    live: 'Feed en directe',
+    snapshot: 'Snapshot verificat',
+    generated: 'Generat',
+    coverage: 'Cobertura',
+    developments: 'Novetats qualificades',
+    immediate: 'Atenció immediata',
+    priorities: 'Vulnerabilitats més prioritzades',
+    cvss: 'CVSS',
+    kev: 'CISA KEV',
+    noKev: 'No KEV',
+    fullReport: 'Llegir l’informe diari complet',
+    repository: 'Veure el repositori d’automatització',
+    liveNote: 'Mostrant el feed compacte més recent publicat automàticament per CyberDailyLog.',
+    snapshotNote: 'Les dades en directe no estan disponibles temporalment. Es mostra el snapshot verificat inclòs al web.',
+    unavailable: 'No s’han pogut carregar les dades de CyberDailyLog. L’informe complet continua disponible a GitHub.',
+    unknown: 'No disponible'
+  }
+};
+
+let activeFeed = null;
+let activeSource = 'loading';
+
+function language() {
+  const value = (document.documentElement.lang || 'en').toLowerCase();
+  return Object.hasOwn(UI, value) ? value : 'en';
+}
+
+function labels() {
+  return UI[language()];
+}
+
+function cleanText(value, maximum = 180) {
+  const text = String(value ?? '').replace(/\s+/g, ' ').trim();
+  return text.slice(0, maximum);
+}
+
+function validDate(value) {
+  const date = new Date(String(value));
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function validateFeed(feed) {
+  if (!feed || typeof feed !== 'object' || Array.isArray(feed)) return false;
+  if (feed.schema_version !== 1 || feed.project !== 'CyberDailyLog') return false;
+  if (!validDate(feed.generated_at) || !validDate(feed.coverage_start) || !validDate(feed.coverage_end)) return false;
+  if (!Number.isInteger(feed.qualified_developments) || feed.qualified_developments < 0) return false;
+  if (!Array.isArray(feed.top_vulnerabilities) || feed.top_vulnerabilities.length > 10) return false;
+  return feed.top_vulnerabilities.every(item => item && typeof item === 'object' && cleanText(item.id, 80));
+}
+
+async function fetchJson(url, timeoutMs = FETCH_TIMEOUT_MS) {
+  const controller = new AbortController();
+  const timeout = window.setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(url, {
+      cache: 'no-store',
+      credentials: 'omit',
+      headers: { Accept: 'application/json' },
+      signal: controller.signal
+    });
+    if (!response.ok) throw new Error(`Feed request failed with ${response.status}`);
+    const data = await response.json();
+    if (!validateFeed(data)) throw new Error('Feed payload failed validation');
+    return data;
+  } finally {
+    window.clearTimeout(timeout);
+  }
+}
+
+function formatDate(value, includeTime = true) {
+  const date = validDate(value);
+  if (!date) return labels().unknown;
+  return new Intl.DateTimeFormat(language(), {
+    dateStyle: 'medium',
+    ...(includeTime ? { timeStyle: 'short' } : {})
+  }).format(date);
+}
+
+function element(tag, className, text) {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text !== undefined) node.textContent = text;
+  return node;
+}
+
+function metric(label, value) {
+  const item = element('div', 'cyberdailylog-metric');
+  item.append(element('span', 'cyberdailylog-metric-label', label));
+  item.append(element('span', 'cyberdailylog-metric-value', value));
+  return item;
+}
+
+function priorityCard(item) {
+  const card = element('article', 'cyberdailylog-priority');
+  const copy = element('div');
+  copy.append(element('span', 'cyberdailylog-priority-id', cleanText(item.id, 80)));
+  copy.append(element('p', 'cyberdailylog-priority-title', cleanText(item.title || item.id, 180)));
+
+  const meta = element('div', 'cyberdailylog-priority-meta');
+  const cvss = Number(item.cvss_score);
+  meta.append(element('span', 'cyberdailylog-chip', `${labels().cvss} ${Number.isFinite(cvss) ? cvss.toFixed(1) : 'n/a'}`));
+  const kev = element('span', 'cyberdailylog-chip', item.cisa_kev ? labels().kev : labels().noKev);
+  kev.dataset.kev = item.cisa_kev ? 'true' : 'false';
+  meta.append(kev);
+
+  card.append(copy, meta);
+  return card;
+}
+
+function render(feed, source) {
+  const root = document.getElementById('cyberdailylogFeed');
+  const status = document.getElementById('cyberdailylogStatus');
+  const note = document.getElementById('cyberdailylogNote');
+  if (!root || !status || !note) return;
+
+  activeFeed = feed;
+  activeSource = source;
+  const text = labels();
+  root.setAttribute('aria-busy', 'false');
+  root.replaceChildren();
+
+  const metrics = element('div', 'cyberdailylog-metrics');
+  metrics.append(
+    metric(text.generated, formatDate(feed.generated_at)),
+    metric(text.coverage, `${formatDate(feed.coverage_start, false)} → ${formatDate(feed.coverage_end, false)}`),
+    metric(text.developments, String(feed.qualified_developments))
+  );
+
+  const attention = element('div', 'cyberdailylog-attention');
+  attention.append(element('strong', '', text.immediate));
+  attention.append(element('p', '', cleanText(feed.immediate_attention, 260) || text.unknown));
+
+  const priorities = element('div', 'cyberdailylog-priorities');
+  priorities.append(element('h3', 'cyberdailylog-priorities-title', text.priorities));
+  feed.top_vulnerabilities.slice(0, MAX_PRIORITIES).forEach(item => priorities.append(priorityCard(item)));
+
+  root.append(metrics, attention, priorities);
+  status.dataset.state = source;
+  status.textContent = source === 'live' ? text.live : text.snapshot;
+  note.dataset.state = source === 'error' ? 'error' : source;
+  note.textContent = source === 'live' ? text.liveNote : text.snapshotNote;
+}
+
+function translateStaticUi() {
+  const text = labels();
+  const navLabel = document.querySelector('.navbar-link[href="#cyberdailylog"] span');
+  const eyebrow = document.getElementById('cyberdailylogEyebrow');
+  const title = document.getElementById('cyberdailylogTitleText');
+  const intro = document.getElementById('cyberdailylogIntro');
+  const reportLink = document.getElementById('cyberdailylogReportLink');
+  const repositoryLink = document.getElementById('cyberdailylogRepositoryLink');
+
+  if (navLabel) navLabel.textContent = text.nav;
+  if (eyebrow) eyebrow.textContent = text.eyebrow;
+  if (title) title.textContent = text.title;
+  if (intro) intro.textContent = text.intro;
+  if (reportLink) reportLink.textContent = text.fullReport;
+  if (repositoryLink) repositoryLink.textContent = text.repository;
+
+  if (activeFeed) render(activeFeed, activeSource);
+  else {
+    const status = document.getElementById('cyberdailylogStatus');
+    if (status) status.textContent = text.loading;
+  }
+}
+
+async function initializeFeed() {
+  translateStaticUi();
+  const root = document.getElementById('cyberdailylogFeed');
+  const note = document.getElementById('cyberdailylogNote');
+  if (!root || !note) return;
+
+  let snapshot = null;
+  try {
+    snapshot = await fetchJson(LOCAL_FEED_URL, 3000);
+    render(snapshot, 'snapshot');
+  } catch {
+    root.setAttribute('aria-busy', 'false');
+    note.dataset.state = 'error';
+    note.textContent = labels().unavailable;
+  }
+
+  try {
+    const remote = await fetchJson(REMOTE_FEED_URL);
+    const remoteTime = validDate(remote.generated_at)?.getTime() ?? 0;
+    const snapshotTime = validDate(snapshot?.generated_at)?.getTime() ?? 0;
+    if (!snapshot || remoteTime >= snapshotTime) render(remote, 'live');
+  } catch {
+    if (snapshot) render(snapshot, 'snapshot');
+  }
+}
+
+new MutationObserver(mutations => {
+  if (mutations.some(mutation => mutation.attributeName === 'lang')) translateStaticUi();
+}).observe(document.documentElement, { attributes: true, attributeFilter: ['lang'] });
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initializeFeed, { once: true });
+} else {
+  initializeFeed();
+}

--- a/assets/js/site-ux.js
+++ b/assets/js/site-ux.js
@@ -1,0 +1,225 @@
+const SCROLL_TOP_LABELS = {
+  en: 'Scroll to top',
+  es: 'Volver arriba',
+  ca: 'Tornar a dalt'
+};
+
+const COMPACT_AT = 360;
+const EXPAND_BELOW = 180;
+const SHOW_SCROLL_TOP_AT = 500;
+const DESKTOP_QUERY = '(min-width: 1025px)';
+
+function currentLanguage() {
+  const language = (document.documentElement.lang || 'en').toLowerCase();
+  return Object.hasOwn(SCROLL_TOP_LABELS, language) ? language : 'en';
+}
+
+function setInteractiveState(container, hidden) {
+  if (!container) return;
+
+  container.setAttribute('aria-hidden', hidden ? 'true' : 'false');
+  if ('inert' in container) container.inert = hidden;
+
+  container.querySelectorAll('a, button, input, select, textarea, [tabindex]').forEach(element => {
+    if (hidden) {
+      if (!element.hasAttribute('data-ux-original-tabindex')) {
+        element.setAttribute(
+          'data-ux-original-tabindex',
+          element.hasAttribute('tabindex') ? element.getAttribute('tabindex') : '__none__'
+        );
+      }
+      element.setAttribute('tabindex', '-1');
+      return;
+    }
+
+    const original = element.getAttribute('data-ux-original-tabindex');
+    if (original === '__none__') element.removeAttribute('tabindex');
+    else if (original !== null) element.setAttribute('tabindex', original);
+    element.removeAttribute('data-ux-original-tabindex');
+  });
+}
+
+function initializeSiteUx() {
+  if (document.documentElement.dataset.siteUx === 'ready') return;
+  document.documentElement.dataset.siteUx = 'ready';
+
+  const body = document.body;
+  const desktopMedia = window.matchMedia(DESKTOP_QUERY);
+  const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+  const scrollingElement = () => document.scrollingElement || document.documentElement;
+
+  const originalNavList = document.querySelector('.navbar-list');
+  const navList = originalNavList ? originalNavList.cloneNode(true) : null;
+  if (originalNavList && navList) originalNavList.replaceWith(navList);
+
+  const navLinks = navList ? Array.from(navList.querySelectorAll('.navbar-link[href^="#"]')) : [];
+  const sections = navLinks
+    .map(link => document.getElementById(link.getAttribute('href')?.slice(1) || ''))
+    .filter(Boolean);
+
+  const originalScrollButton = document.getElementById('scrollTop');
+  const scrollButton = originalScrollButton ? originalScrollButton.cloneNode(false) : null;
+
+  if (originalScrollButton && scrollButton) {
+    originalScrollButton.replaceWith(scrollButton);
+    scrollButton.type = 'button';
+    scrollButton.innerHTML = `
+      <svg class="scroll-btn-icon" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+        <path d="M6 14.5 12 8l6 6.5"></path>
+        <path d="M12 8v10"></path>
+      </svg>
+    `;
+  }
+
+  const avatar = document.querySelector('.avatar-bg');
+  const contacts = document.querySelector('.contacts-list');
+  const separators = Array.from(document.querySelectorAll('.sidebar-info > .separator'));
+  const consent = document.getElementById('consent');
+  let condensed = false;
+  let animationFrame = 0;
+  let activeSectionId = '';
+
+  function updateScrollButtonLabel() {
+    if (!scrollButton) return;
+    const label = SCROLL_TOP_LABELS[currentLanguage()];
+    scrollButton.setAttribute('aria-label', label);
+    scrollButton.setAttribute('title', label);
+  }
+
+  function updateConsentOffset() {
+    let offset = 0;
+    if (consent && consent.isConnected && !consent.hidden) {
+      const style = window.getComputedStyle(consent);
+      const rect = consent.getBoundingClientRect();
+      if (style.display !== 'none' && style.visibility !== 'hidden' && rect.height > 0) {
+        offset = Math.max(0, window.innerHeight - rect.top + 12);
+      }
+    }
+    document.documentElement.style.setProperty('--scroll-top-consent-offset', `${Math.ceil(offset)}px`);
+  }
+
+  function setCondensed(nextCondensed) {
+    const next = desktopMedia.matches && nextCondensed;
+    if (next === condensed && contacts?.getAttribute('aria-hidden') !== null) return;
+
+    condensed = next;
+    body.classList.toggle('sidebar-condensed', condensed);
+    setInteractiveState(contacts, condensed);
+    if (avatar) avatar.setAttribute('aria-hidden', condensed ? 'true' : 'false');
+    separators.forEach(separator => separator.setAttribute('aria-hidden', condensed ? 'true' : 'false'));
+  }
+
+  function setScrollButtonVisible(visible) {
+    if (!scrollButton) return;
+    scrollButton.classList.toggle('visible', visible);
+    scrollButton.setAttribute('aria-hidden', visible ? 'false' : 'true');
+    scrollButton.setAttribute('tabindex', visible ? '0' : '-1');
+  }
+
+  function keepActiveLinkVisible(link) {
+    if (!navList || !link || !desktopMedia.matches) return;
+    const navRect = navList.getBoundingClientRect();
+    const linkRect = link.getBoundingClientRect();
+    if (linkRect.top < navRect.top || linkRect.bottom > navRect.bottom) {
+      link.scrollIntoView({ block: 'nearest', inline: 'nearest', behavior: 'auto' });
+    }
+  }
+
+  function setActiveSection(sectionId) {
+    if (!sectionId || sectionId === activeSectionId) return;
+    activeSectionId = sectionId;
+
+    navLinks.forEach(link => {
+      const active = link.getAttribute('href') === `#${sectionId}`;
+      link.classList.toggle('active', active);
+      if (active) link.setAttribute('aria-current', 'location');
+      else link.removeAttribute('aria-current');
+    });
+
+    keepActiveLinkVisible(navLinks.find(link => link.getAttribute('href') === `#${sectionId}`));
+  }
+
+  function updateActiveSection() {
+    if (!sections.length) return;
+
+    const scroller = scrollingElement();
+    const atDocumentEnd = scroller.scrollTop + window.innerHeight >= scroller.scrollHeight - 4;
+    if (atDocumentEnd) {
+      setActiveSection(sections.at(-1).id);
+      return;
+    }
+
+    const readingLine = Math.min(window.innerHeight * 0.38, 320);
+    const crossed = sections.filter(section => section.getBoundingClientRect().top <= readingLine);
+    const candidate = crossed.at(-1) || sections[0];
+    setActiveSection(candidate.id);
+  }
+
+  function updateScrollState() {
+    animationFrame = 0;
+    const scrollTop = scrollingElement().scrollTop;
+
+    if (!desktopMedia.matches) setCondensed(false);
+    else if (!condensed && scrollTop >= COMPACT_AT) setCondensed(true);
+    else if (condensed && scrollTop <= EXPAND_BELOW) setCondensed(false);
+
+    setScrollButtonVisible(scrollTop >= SHOW_SCROLL_TOP_AT);
+    updateConsentOffset();
+    updateActiveSection();
+  }
+
+  function requestScrollStateUpdate() {
+    if (!animationFrame) animationFrame = window.requestAnimationFrame(updateScrollState);
+  }
+
+  navLinks.forEach(link => {
+    link.addEventListener('click', () => {
+      const sectionId = link.getAttribute('href')?.slice(1);
+      if (sectionId) setActiveSection(sectionId);
+    });
+  });
+
+  if (scrollButton) {
+    scrollButton.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: reduceMotion.matches ? 'auto' : 'smooth' });
+    });
+  }
+
+  new MutationObserver(updateScrollButtonLabel).observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['lang']
+  });
+
+  if (consent) {
+    new MutationObserver(updateConsentOffset).observe(consent, {
+      attributes: true,
+      attributeFilter: ['hidden', 'style', 'class']
+    });
+    if ('ResizeObserver' in window) new ResizeObserver(updateConsentOffset).observe(consent);
+  }
+
+  if ('IntersectionObserver' in window) {
+    const observer = new IntersectionObserver(requestScrollStateUpdate, {
+      root: null,
+      rootMargin: '0px',
+      threshold: [0, 0.01, 0.1, 0.25, 0.5]
+    });
+    sections.forEach(section => observer.observe(section));
+  }
+
+  window.addEventListener('scroll', requestScrollStateUpdate, { passive: true });
+  window.addEventListener('resize', requestScrollStateUpdate, { passive: true });
+  desktopMedia.addEventListener('change', requestScrollStateUpdate);
+  reduceMotion.addEventListener('change', requestScrollStateUpdate);
+
+  updateScrollButtonLabel();
+  setInteractiveState(contacts, false);
+  setScrollButtonVisible(false);
+  updateScrollState();
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initializeSiteUx, { once: true });
+} else {
+  initializeSiteUx();
+}

--- a/assets/js/site-ux.js
+++ b/assets/js/site-ux.js
@@ -185,21 +185,21 @@ function initializeSiteUx() {
     });
   }
 
-  new MutationObserver(updateScrollButtonLabel).observe(document.documentElement, {
+  new window.MutationObserver(updateScrollButtonLabel).observe(document.documentElement, {
     attributes: true,
     attributeFilter: ['lang']
   });
 
   if (consent) {
-    new MutationObserver(updateConsentOffset).observe(consent, {
+    new window.MutationObserver(updateConsentOffset).observe(consent, {
       attributes: true,
       attributeFilter: ['hidden', 'style', 'class']
     });
-    if ('ResizeObserver' in window) new ResizeObserver(updateConsentOffset).observe(consent);
+    if ('ResizeObserver' in window) new window.ResizeObserver(updateConsentOffset).observe(consent);
   }
 
   if ('IntersectionObserver' in window) {
-    const observer = new IntersectionObserver(requestScrollStateUpdate, {
+    const observer = new window.IntersectionObserver(requestScrollStateUpdate, {
       root: null,
       rootMargin: '0px',
       threshold: [0, 0.01, 0.1, 0.25, 0.5]

--- a/index.html
+++ b/index.html
@@ -3,21 +3,19 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <meta name="description" content="JimBLogic - Junior SOC Analyst / Blue Team candidate with Raspberry Pi 4 defensive homelab, Linux, Docker, networking, monitoring and AWS cloud foundations" />
-  <meta name="keywords" content="cybersecurity, ethical hacking, penetration testing, digital forensics, cloud security, AWS, Python, Linux, OSINT, threat analysis" />
+  <meta name="description" content="JimBLogic - Junior SOC Analyst / Blue Team candidate with Raspberry Pi 4 defensive homelab, automated CyberDailyLog intelligence, Linux, Docker, networking, monitoring and AWS cloud foundations" />
+  <meta name="keywords" content="cybersecurity, blue team, SOC analyst, threat intelligence, CyberDailyLog, digital forensics, cloud security, AWS, Python, Linux, OSINT" />
   <meta name="author" content="Jaime Ramsden de Frutos" />
   <meta name="robots" content="index, follow" />
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
-  <!-- Open Graph Meta Tags -->
   <meta property="og:title" content="JimBLogic | Cybersecurity Portfolio" />
-  <meta property="og:description" content="Junior SOC Analyst / Blue Team candidate documenting defensive homelab work, logs, monitoring, hardening, digital forensics foundations and AWS cloud learning." />
+  <meta property="og:description" content="Junior SOC Analyst / Blue Team candidate documenting defensive homelab work, automated daily threat intelligence, monitoring, hardening and AWS cloud learning." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://jimblogic.github.io" />
   <meta property="og:image" content="https://jimblogic.github.io/assets/Images/Profilepicandother/my-avatar.png" />
 
-  <!-- Twitter Card Meta Tags -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="JimBLogic | Cybersecurity Portfolio" />
   <meta name="twitter:description" content="Junior SOC Analyst / Blue Team Candidate" />
@@ -28,10 +26,12 @@
   <link rel="shortcut icon" href="https://cdn.jsdelivr.net/npm/simple-icons@v11/icons/bitcoin.svg" type="image/svg+xml">
   <meta name="build-version" content="%VITE_BUILD_VERSION%" />
   <link rel="stylesheet" href="./assets/css/style.css?v=%VITE_BUILD_VERSION%">
+  <link rel="stylesheet" href="./assets/css/scroll-sidebar-ux.css?v=%VITE_BUILD_VERSION%">
+  <link rel="stylesheet" href="./assets/css/cyberdailylog.css?v=%VITE_BUILD_VERSION%">
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;500;700&display=swap" rel="stylesheet">
   <script type="module" src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.esm.js"></script>
   <script nomodule src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.js"></script>
-  <!-- Structured data for SEO and rich results -->
+
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -44,7 +44,7 @@
     ],
     "jobTitle": "Junior SOC Analyst / Blue Team Candidate",
     "email": "mailto:jrf91@pm.me",
-    "knowsAbout": ["SOC analysis","blue team operations","Linux","Docker","network monitoring","digital forensics","incident response","OSINT","AWS cloud foundations"]
+    "knowsAbout": ["SOC analysis","blue team operations","threat intelligence","Linux","Docker","network monitoring","digital forensics","incident response","OSINT","AWS cloud foundations"]
   }
   </script>
   <link rel="canonical" href="https://jimblogic.github.io/" />
@@ -54,8 +54,8 @@
     "@type": "SoftwareSourceCode",
     "name": "CyberDailyLog",
     "url": "https://github.com/JimBLogic/CyberDailyLog",
-    "description": "Blue Team intelligence and defensive lab reporting project with daily-intel reports, CSV validation, pre-commit hooks, and CI.",
-    "programmingLanguage": "PowerShell, Python",
+    "description": "Automated, source-backed 24-hour Blue Team intelligence pipeline with reproducible reports and a compact public portfolio feed.",
+    "programmingLanguage": "Python",
     "codeRepository": "https://github.com/JimBLogic/CyberDailyLog",
     "license": "https://opensource.org/licenses/MIT",
     "creator": {
@@ -68,7 +68,6 @@
 </head>
 <body>
 
-<!-- Skip link for keyboard users -->
 <a class="skip-link" href="#maincontent">Skip to main content</a>
 
 <header class="site-header" role="banner">
@@ -77,22 +76,21 @@
 
 <div class="bg-animation"></div>
 
-  <!-- Site entity structured data -->
-  <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "WebSite",
-    "name": "JimBLogic Portfolio",
-    "url": "https://jimblogic.github.io/",
-    "potentialAction": {
-      "@type": "SearchAction",
-      "target": "https://jimblogic.github.io/?q={search_term_string}",
-      "query-input": "required name=search_term_string"
-    }
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "name": "JimBLogic Portfolio",
+  "url": "https://jimblogic.github.io/",
+  "potentialAction": {
+    "@type": "SearchAction",
+    "target": "https://jimblogic.github.io/?q={search_term_string}",
+    "query-input": "required name=search_term_string"
   }
-  </script>
-<div class="container">
+}
+</script>
 
+<div class="container">
   <aside class="sidebar" role="complementary" aria-label="Sidebar">
     <div class="lang-switch">
       <button data-lang="en">EN</button>
@@ -140,9 +138,11 @@
           <li><a class="navbar-link active" href="#about" data-txt="about">
             <ion-icon name="person-outline" aria-hidden="true"></ion-icon><span>About</span>
           </a></li>
-          <!-- Certifications removed from sidebar nav (kept on page) -->
           <li><a class="navbar-link" href="#focus" data-txt="focus">
             <ion-icon name="radio-outline" aria-hidden="true"></ion-icon><span>Current Focus</span>
+          </a></li>
+          <li><a class="navbar-link" href="#cyberdailylog">
+            <ion-icon name="pulse-outline" aria-hidden="true"></ion-icon><span>CyberDailyLog</span>
           </a></li>
           <li><a class="navbar-link" href="#skills" data-txt="skills">
             <ion-icon name="code-slash-outline" aria-hidden="true"></ion-icon><span>Skills</span>
@@ -176,7 +176,6 @@
   <main id="maincontent" class="main-content" role="main" aria-label="Main content">
     <h1 class="sr-only">JimBLogic — Cybersecurity Portfolio</h1>
 
-    <!-- About -->
     <section id="about" class="main-section">
       <h2 data-txt="about"><ion-icon name="person-circle-outline" aria-hidden="true"></ion-icon>About Me</h2>
       <div class="hero-panel">
@@ -205,8 +204,6 @@
       </p>
     </section>
 
-
-    <!-- Current Focus -->
     <section id="focus" class="main-section">
       <h2 data-txt="focus"><ion-icon name="radio-outline" aria-hidden="true"></ion-icon>Current Focus</h2>
       <div class="focus-grid">
@@ -225,16 +222,29 @@
       </div>
     </section>
 
-    <!-- Certifications -->
+    <section id="cyberdailylog" class="main-section cyberdailylog-section" aria-labelledby="cyberdailylogTitle">
+      <div class="cyberdailylog-heading">
+        <div>
+          <p id="cyberdailylogEyebrow" class="cyberdailylog-eyebrow">Automated Blue Team intelligence</p>
+          <h2 id="cyberdailylogTitle"><ion-icon name="pulse-outline" aria-hidden="true"></ion-icon><span id="cyberdailylogTitleText">CyberDailyLog</span></h2>
+        </div>
+        <span id="cyberdailylogStatus" class="cyberdailylog-status" data-state="loading" aria-live="polite">Loading feed</span>
+      </div>
+      <p id="cyberdailylogIntro" class="cyberdailylog-intro">A daily, source-backed intelligence pipeline that collects, validates and prioritises defensive developments. This compact view updates automatically while the complete report remains auditable on GitHub.</p>
+      <div id="cyberdailylogFeed" class="cyberdailylog-feed" aria-live="polite" aria-busy="true"></div>
+      <div class="cyberdailylog-actions">
+        <a id="cyberdailylogReportLink" class="btn-link" href="https://github.com/JimBLogic/CyberDailyLog/blob/main/reports/latest.md" target="_blank" rel="noopener noreferrer">Read full daily brief</a>
+        <a id="cyberdailylogRepositoryLink" class="btn-link btn-link-secondary" href="https://github.com/JimBLogic/CyberDailyLog" target="_blank" rel="noopener noreferrer">View automation repository</a>
+      </div>
+      <p id="cyberdailylogNote" class="cyberdailylog-note">Loading the bundled verified snapshot.</p>
+    </section>
+
     <section id="certifications" class="main-section">
       <h2 data-txt="certifications"><ion-icon name="medal-outline" aria-hidden="true"></ion-icon>Certifications</h2>
       <div id="certFilters" class="filters"></div>
-      <ul class="certificate-list" id="certificateList">
-        <!-- Certificates loaded via JavaScript -->
-      </ul>
+      <ul class="certificate-list" id="certificateList"></ul>
     </section>
 
-    <!-- Skills -->
     <section id="skills" class="main-section">
       <h2 data-txt="skills"><ion-icon name="code-slash-outline" aria-hidden="true"></ion-icon>Skills</h2>
       <p data-txt="skills_intro" class="section-intro">My skills are junior-level, practical and lab-driven: enough to contribute carefully, ask good questions and keep improving through documented hands-on work.</p>
@@ -249,7 +259,6 @@
       </ul>
     </section>
 
-    <!-- Education -->
     <section id="education" class="main-section">
       <h2 data-txt="education"><ion-icon name="school-outline" aria-hidden="true"></ion-icon>Education</h2>
       <div class="education-item">
@@ -264,11 +273,9 @@
       </div>
     </section>
 
-    <!-- Passion & Interests -->
     <section id="passion" class="main-section">
       <h2 data-txt="passion"><ion-icon name="heart-outline" aria-hidden="true"></ion-icon>Passion & Interests</h2>
       <p data-txt="passion_intro" class="section-intro">Beyond technical skills, I'm driven by curiosity and a commitment to financial sovereignty and privacy.</p>
-
       <div class="passion-grid">
         <div class="passion-card">
           <ion-icon name="logo-bitcoin" class="passion-icon" aria-hidden="true"></ion-icon>
@@ -276,20 +283,17 @@
           <p data-txt="passion_bitcoin_desc">Running my own Bitcoin Lightning node to support the decentralized network and promote financial freedom. I believe in self-custody, peer-to-peer transactions, and the importance of sound money principles.</p>
           <p><a href="https://amboss.space/es/node/02ec23c7c0c1adb58a46f6ca5a5acbcebfb2972ede2ed6ba73de605fda5288509f" target="_blank" rel="noopener" data-txt="passion_bitcoin_link">View my Lightning Node →</a></p>
         </div>
-
         <div class="passion-card">
           <ion-icon name="shield-checkmark-outline" class="passion-icon" aria-hidden="true"></ion-icon>
           <h3 data-txt="passion_privacy_title">Privacy & Open Source</h3>
           <p data-txt="passion_privacy_desc">Advocate for digital privacy and open-source software. I use privacy-focused tools like Proton Mail, contribute to open-source projects, and believe everyone deserves control over their personal data.</p>
         </div>
-
         <div class="passion-card">
           <ion-icon name="book-outline" class="passion-icon" aria-hidden="true"></ion-icon>
           <h3 data-txt="passion_learning_title">Continuous Learning</h3>
           <p data-txt="passion_learning_desc">Cybersecurity is ever-evolving, and I'm passionate about staying ahead. From capture-the-flag competitions to reading security research papers, I'm always expanding my knowledge and testing new techniques.</p>
           <p><a href="#journey" data-txt="passion_learning_link">Explore my learning journey →</a></p>
         </div>
-
         <div class="passion-card">
           <ion-icon name="globe-outline" class="passion-icon" aria-hidden="true"></ion-icon>
           <h3 data-txt="passion_community_title">Community & Collaboration</h3>
@@ -299,57 +303,41 @@
       </div>
     </section>
 
-    <!-- Software -->
     <section id="software" class="main-section">
       <h2 data-txt="software"><ion-icon name="desktop-outline" aria-hidden="true"></ion-icon>Software</h2>
-      <ul class="software-list" id="softwareList">
-        <!-- Software loaded via JavaScript -->
-      </ul>
+      <ul class="software-list" id="softwareList"></ul>
     </section>
 
-    <!-- Learning Journey -->
     <section id="journey" class="main-section">
       <h2 data-txt="journey"><ion-icon name="map-outline" aria-hidden="true"></ion-icon>Learning Journey</h2>
       <div class="journey-grid" id="journeyGrid"></div>
     </section>
 
-    <!-- Projects -->
     <section id="projects" class="main-section">
       <h2 data-txt="projects"><ion-icon name="folder-open-outline" aria-hidden="true"></ion-icon>Projects</h2>
       <p class="section-intro" data-txt="projects_intro">Real repositories are loaded from GitHub. The featured item is selected to show practical proof of work; active lab work is marked honestly as currently building.</p>
       <div class="projects-toggle-wrap">
         <button id="projectsToggle" class="filter-btn" data-txt="projects_expand" aria-controls="projectsList" aria-expanded="false">Expand</button>
       </div>
-      <ul class="projects-list" id="projectsList">
-        <!-- Projects loaded via JavaScript from GitHub API -->
-      </ul>
+      <ul class="projects-list" id="projectsList"></ul>
     </section>
 
-    <!-- Tools -->
     <section id="tools" class="main-section">
       <h2 data-txt="tools"><ion-icon name="build-outline" aria-hidden="true"></ion-icon>Tools</h2>
-      <ul class="tools-list" id="toolsList">
-        <!-- Tools loaded via JavaScript -->
-      </ul>
+      <ul class="tools-list" id="toolsList"></ul>
     </section>
 
-    <!-- Contact -->
     <section id="contact" class="main-section">
       <h2 data-txt="contact"><ion-icon name="mail-outline" aria-hidden="true"></ion-icon>Contact</h2>
       <p data-txt="contact_1">Ready to collaborate? Reach out via email:</p>
-  <p><a href="mailto:jrf91@pm.me" class="contact-link">jrf91@pm.me</a></p>
+      <p><a href="mailto:jrf91@pm.me" class="contact-link">jrf91@pm.me</a></p>
       <p data-txt="contact_2">Or connect via <a href="https://www.linkedin.com/in/jimblogic/" target="_blank" rel="noopener noreferrer">LinkedIn</a></p>
     </section>
-
   </main>
 </div>
 
-<!-- Scroll to Top Button (only visible when scrolled down) -->
-  <button class="scroll-btn scroll-top" id="scrollTop" title="Scroll to top">
-  <ion-icon name="chevron-up-outline" aria-hidden="true"></ion-icon>
-</button>
+<button class="scroll-btn scroll-top" id="scrollTop" type="button" title="Scroll to top" aria-label="Scroll to top"></button>
 
-<!-- Consent banner for analytics (opt-in) -->
 <div id="consent" role="dialog" aria-live="polite" aria-modal="true" aria-label="Analytics consent" class="consent" hidden>
   <p>Allow anonymous analytics to improve the site?</p>
   <div>
@@ -358,18 +346,18 @@
   </div>
 </div>
 
-<!-- Plausible analytics (manual mode; only fires after consent) -->
 <script id="plausible" defer data-domain="jimblogic.github.io" src="https://plausible.io/js/script.js" data-manual></script>
-
 <script type="module" src="./assets/js/translate.js?v=%VITE_BUILD_VERSION%" defer></script>
 <script type="module" src="./assets/js/script.js?v=%VITE_BUILD_VERSION%" defer></script>
-  <!-- Footer -->
-  <footer role="contentinfo" class="site-footer">
-    <div class="site-footer-row">
-      <small>© 2025 Jaime Ramsden de Frutos · <a href="LICENSE" class="footer-link">MIT License</a></small>
-      <a href="https://pages.github.com/" target="_blank" rel="noopener" class="footer-link">Powered by GitHub Pages</a>
-    </div>
-    <div class="site-footer-source">View source on <a href="https://github.com/JimBLogic/jimblogic.github.io" target="_blank" rel="noopener" class="footer-link">GitHub</a></div>
-  </footer>
+<script type="module" src="./assets/js/cyberdailylog-feed.js?v=%VITE_BUILD_VERSION%" defer></script>
+<script type="module" src="./assets/js/site-ux.js?v=%VITE_BUILD_VERSION%" defer></script>
+
+<footer role="contentinfo" class="site-footer">
+  <div class="site-footer-row">
+    <small>© 2025 Jaime Ramsden de Frutos · <a href="LICENSE" class="footer-link">MIT License</a></small>
+    <a href="https://pages.github.com/" target="_blank" rel="noopener" class="footer-link">Powered by GitHub Pages</a>
+  </div>
+  <div class="site-footer-source">View source on <a href="https://github.com/JimBLogic/jimblogic.github.io" target="_blank" rel="noopener" class="footer-link">GitHub</a></div>
+</footer>
 </body>
 </html>

--- a/tests/cyberdailylog-feed.spec.js
+++ b/tests/cyberdailylog-feed.spec.js
@@ -1,0 +1,108 @@
+import { test, expect } from '@playwright/test';
+import { openHome } from './helpers';
+
+const remoteFeedUrl = 'https://raw.githubusercontent.com/JimBLogic/CyberDailyLog/main/reports/portfolio-feed.json';
+
+function liveFeed(overrides = {}) {
+  return {
+    schema_version: 1,
+    project: 'CyberDailyLog',
+    title: 'Blue Team Intelligence Digest',
+    generated_at: '2026-07-17T08:34:06+00:00',
+    coverage_start: '2026-07-16T08:33:48+00:00',
+    coverage_end: '2026-07-17T08:33:48+00:00',
+    degraded: false,
+    qualified_developments: 42,
+    immediate_attention: 'One source-backed item requires immediate defensive review.',
+    source_health: { total: 6, status_counts: { healthy: 6 } },
+    report_url: 'https://github.com/JimBLogic/CyberDailyLog/blob/main/reports/latest.md',
+    repository_url: 'https://github.com/JimBLogic/CyberDailyLog',
+    top_vulnerabilities: [
+      {
+        id: 'CVE-2026-99999',
+        title: '<img id="remote-injection" src=x onerror=alert(1)> Critical browser issue',
+        cvss_score: 9.8,
+        cisa_kev: true,
+        known_exploited: true
+      }
+    ],
+    ...overrides
+  };
+}
+
+async function prepare(page, routeHandler) {
+  await page.setViewportSize({ width: 1366, height: 768 });
+  await page.addInitScript(() => localStorage.clear());
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  await page.route(remoteFeedUrl, routeHandler);
+  return openHome(page);
+}
+
+test('renders the current remote feed as safe live portfolio content', async ({ page }) => {
+  const guard = await prepare(page, route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(liveFeed())
+  }));
+
+  const section = page.locator('#cyberdailylog');
+  await expect(section).toBeVisible();
+  await expect(page.locator('#cyberdailylogStatus')).toHaveAttribute('data-state', 'live');
+  await expect(page.locator('#cyberdailylogStatus')).toHaveText('Live feed');
+  await expect(section).toContainText('42');
+  await expect(section).toContainText('CVE-2026-99999');
+  await expect(section).toContainText('CVSS 9.8');
+  await expect(section).toContainText('CISA KEV');
+  await expect(section).toContainText('<img id="remote-injection"');
+  await expect(page.locator('#remote-injection')).toHaveCount(0);
+  await expect(page.locator('#cyberdailylogReportLink')).toHaveAttribute(
+    'href',
+    'https://github.com/JimBLogic/CyberDailyLog/blob/main/reports/latest.md'
+  );
+  guard.assertNoSameOriginFailures();
+});
+
+test('falls back to the bundled verified snapshot when the remote feed fails', async ({ page }) => {
+  const guard = await prepare(page, route => route.fulfill({ status: 503, body: 'unavailable' }));
+
+  await expect(page.locator('#cyberdailylogStatus')).toHaveAttribute('data-state', 'snapshot');
+  await expect(page.locator('#cyberdailylogStatus')).toHaveText('Verified snapshot');
+  await expect(page.locator('#cyberdailylog')).toContainText('331');
+  await expect(page.locator('#cyberdailylog')).toContainText('CVE-2026-62948');
+  await expect(page.locator('#cyberdailylogNote')).toContainText('bundled verified snapshot');
+  guard.assertNoSameOriginFailures();
+});
+
+test('rejects an invalid remote schema and preserves the local snapshot', async ({ page }) => {
+  const guard = await prepare(page, route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ project: 'UnexpectedProject', top_vulnerabilities: [] })
+  }));
+
+  await expect(page.locator('#cyberdailylogStatus')).toHaveAttribute('data-state', 'snapshot');
+  await expect(page.locator('#cyberdailylog')).toContainText('331');
+  guard.assertNoSameOriginFailures();
+});
+
+test('updates CyberDailyLog controls and dynamic labels in EN, ES and CA', async ({ page }) => {
+  const guard = await prepare(page, route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(liveFeed())
+  }));
+
+  await expect(page.locator('#cyberdailylogStatus')).toHaveText('Live feed');
+  await expect(page.locator('#cyberdailylogReportLink')).toHaveText('Read full daily brief');
+
+  await page.locator('button[data-lang="es"]').click();
+  await expect(page.locator('#cyberdailylogStatus')).toHaveText('Feed en directo');
+  await expect(page.locator('#cyberdailylogReportLink')).toHaveText('Leer informe diario completo');
+  await expect(page.locator('#cyberdailylogIntro')).toContainText('pipeline diario');
+
+  await page.locator('button[data-lang="ca"]').click();
+  await expect(page.locator('#cyberdailylogStatus')).toHaveText('Feed en directe');
+  await expect(page.locator('#cyberdailylogReportLink')).toHaveText('Llegir l’informe diari complet');
+  await expect(page.locator('#cyberdailylogIntro')).toContainText('pipeline diari');
+  guard.assertNoSameOriginFailures();
+});

--- a/tests/scroll-sidebar-ux.spec.js
+++ b/tests/scroll-sidebar-ux.spec.js
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { openHome } from './helpers';
 
-const sectionIds = ['about', 'focus', 'skills', 'education', 'passion', 'software', 'journey', 'projects', 'tools', 'contact'];
+const sectionIds = ['about', 'focus', 'cyberdailylog', 'skills', 'education', 'passion', 'software', 'journey', 'projects', 'tools', 'contact'];
 const languageLabels = {
   en: 'Scroll to top',
   es: 'Volver arriba',
@@ -138,7 +138,7 @@ for (const lang of ['en', 'es', 'ca']) {
     const guard = await stablePage(page);
     await page.locator(`button[data-lang="${lang}"]`).click();
 
-    for (const id of ['projects', 'tools', 'contact']) {
+    for (const id of ['cyberdailylog', 'projects', 'tools', 'contact']) {
       await scrollToSection(page, id);
       const link = page.locator(`.navbar-link[href="#${id}"]`);
       await expect(link).toHaveAttribute('aria-current', 'location');

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,7 +39,7 @@ export default defineConfig({
         { src: 'assets/js', dest: '.' },
         { src: 'assets/locales', dest: '.' },
         { src: 'assets/pdfs', dest: '.' },
-        { src: 'assets/data/*', dest: 'assets/data' },
+        { src: 'assets/data', dest: '.' },
         { src: 'assets/Jamie Ramsden CV.pdf', dest: '.' },
         { src: 'assets/Jamie Ramsden Cover Letter.pdf', dest: '.' },
         { src: 'UpgradeHub', dest: '.' },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,7 +39,7 @@ export default defineConfig({
         { src: 'assets/js', dest: '.' },
         { src: 'assets/locales', dest: '.' },
         { src: 'assets/pdfs', dest: '.' },
-        { src: 'assets/data', dest: 'assets' },
+        { src: 'assets/data/*', dest: 'assets/data' },
         { src: 'assets/Jamie Ramsden CV.pdf', dest: '.' },
         { src: 'assets/Jamie Ramsden Cover Letter.pdf', dest: '.' },
         { src: 'UpgradeHub', dest: '.' },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,18 +10,9 @@ const hardenGeneratedHtml = {
       "script-src 'self' https://unpkg.com https://cdn.jsdelivr.net https://plausible.io;"
     );
 
-    const withUxStyles = withPlausibleCsp.replace(
+    return withPlausibleCsp.replace(
       '</head>',
-      [
-        '  <link rel="stylesheet" href="./assets/css/qa-fixes.css">',
-        '  <link rel="stylesheet" href="./assets/css/scroll-sidebar-ux.css">',
-        '</head>'
-      ].join('\n')
-    );
-
-    return withUxStyles.replace(
-      '</body>',
-      '  <script type="module" src="./assets/js/scroll-sidebar-ux.js"></script>\n</body>'
+      ['  <link rel="stylesheet" href="./assets/css/qa-fixes.css">', '</head>'].join('\n')
     );
   }
 };
@@ -48,6 +39,7 @@ export default defineConfig({
         { src: 'assets/js', dest: '.' },
         { src: 'assets/locales', dest: '.' },
         { src: 'assets/pdfs', dest: '.' },
+        { src: 'assets/data', dest: 'assets' },
         { src: 'assets/Jamie Ramsden CV.pdf', dest: '.' },
         { src: 'assets/Jamie Ramsden Cover Letter.pdf', dest: '.' },
         { src: 'UpgradeHub', dest: '.' },


### PR DESCRIPTION
## Purpose

Turn the static GitHub Pages portfolio into a safe hybrid consumer of the automated CyberDailyLog pipeline.

## Changes

- add a dedicated CyberDailyLog section and sidebar destination;
- render the compact remote feed from `CyberDailyLog/reports/portfolio-feed.json`;
- load a bundled verified snapshot immediately and retain it when the remote feed is unavailable or invalid;
- validate the remote schema and render all external data with DOM nodes and `textContent`, never remote HTML;
- present generated time, coverage, qualified developments, immediate-attention status and five priority vulnerabilities;
- translate the complete component in EN, ES and CA;
- add focused Playwright coverage for live data, fallback, schema rejection, XSS resistance and translations;
- activate the previously merged document-scroll/progressive-sidebar CSS and replace the inactive JavaScript with a dynamic section-aware implementation.

## Reliability

The portfolio remains fully static and deployable on GitHub Pages. CyberDailyLog continues to own collection and automation. The browser receives a compact live feed when available and falls back to a versioned local snapshot without breaking the rest of the portfolio.