### PR TITLE
Publish the tested Vite artifact to the active Pages branch

### DIFF
--- a/.github/workflows/site-qa-pages.yml
+++ b/.github/workflows/site-qa-pages.yml
@@ -37,6 +37,8 @@ jobs:
         run: |
           node --check assets/js/script.js
           node --check assets/js/translate.js
+          node --check assets/js/cyberdailylog-feed.js
+          node --check assets/js/site-ux.js
           node --check scripts/generate-build-version.mjs
           node --check scripts/validate-local.mjs
           node --check scripts/audit-production.mjs
@@ -71,6 +73,8 @@ jobs:
         run: |
           test ! -e dist/assets/MyLinkedinInfo
           node scripts/validate-artifact-privacy.mjs --dist-dir dist
+      - name: Verify CyberDailyLog fallback is in the artifact
+        run: test -s dist/assets/data/cyberdailylog-latest.json
       - name: Verify tracked source stayed clean after build
         run: |
           git diff --exit-code
@@ -95,30 +99,56 @@ jobs:
             test-results/
           retention-days: 10
           if-no-files-found: ignore
-      - name: Configure Pages
+      - name: Upload tested deployment artifact
         if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0 verified release
-      - name: Upload tested Pages artifact
-        if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1 verified release
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3 verified release
         with:
+          name: tested-pages-${{ steps.build_version.outputs.version }}
           path: dist
+          retention-days: 2
+          if-no-files-found: error
+
   deploy:
-    name: Deploy tested artifact
+    name: Publish tested artifact to gh-pages
     needs: qa
     if: ${{ needs.qa.result == 'success' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      contents: write
     steps:
-      - name: Deploy tested Pages artifact
-        id: deployment
-        uses: actions/deploy-pages@d6f0a3c8e1cfa9bf4f23135a08848de91a0fcb19 # v4.0.5 verified release
+      - name: Checkout repository with publication credentials
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7 verified release
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+      - name: Download tested deployment artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0 verified release
+        with:
+          name: tested-pages-${{ needs.qa.outputs.build_version }}
+          path: ${{ runner.temp }}/tested-pages
+      - name: Verify downloaded artifact
+        env:
+          EXPECTED_VERSION: ${{ needs.qa.outputs.build_version }}
+        run: |
+          set -euo pipefail
+          test -s "$RUNNER_TEMP/tested-pages/index.html"
+          test -s "$RUNNER_TEMP/tested-pages/assets/data/cyberdailylog-latest.json"
+          grep -Fq "<meta name=\"build-version\" content=\"$EXPECTED_VERSION\"" "$RUNNER_TEMP/tested-pages/index.html"
+      - name: Publish immutable tested files to gh-pages
+        env:
+          BUILD_VERSION: ${{ needs.qa.outputs.build_version }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout --orphan gh-pages-publish
+          git rm -rf .
+          cp -a "$RUNNER_TEMP/tested-pages/." .
+          touch .nojekyll
+          git add -A
+          git commit -m "deploy: publish tested portfolio ${BUILD_VERSION}"
+          git push --force origin HEAD:gh-pages
+
   production-audit:
     name: Production audit
     needs: [qa, deploy]


### PR DESCRIPTION
## Problem

The portfolio source and hybrid CyberDailyLog integration are merged into `main`, but the public site continues to serve an older deployment. The repository still has a long-lived `gh-pages` publication branch with unrelated history, so source commits in `main` do not reliably become the public Pages content.

## Solution

- keep the full QA, privacy, Chromium, Axe and responsive gates;
- upload the exact `dist/` directory that passed those gates;
- verify the CyberDailyLog fallback snapshot and canonical build version inside the downloaded artifact;
- publish that immutable tested artifact to `gh-pages` only after QA succeeds;
- run the existing cache-busted production audit with retries after publication;
- syntax-check the newly active CyberDailyLog and site UX modules.

## Safety

The existing `gh-pages` history was preserved before this PR in `archive/gh-pages-before-hybrid-deploy-2026-07-16`. The workflow never publishes source files or an untested rebuild: it promotes the exact artifact produced and exercised by the QA job.