### PR TITLE
Fix Pages publishing, consent dismissal and sidebar clipping

### DIFF
--- a/.github/workflows/site-qa-pages.yml
+++ b/.github/workflows/site-qa-pages.yml
@@ -39,6 +39,7 @@ jobs:
           node --check assets/js/translate.js
           node --check assets/js/cyberdailylog-feed.js
           node --check assets/js/site-ux.js
+          node --check assets/js/stability-hotfix.js
           node --check scripts/generate-build-version.mjs
           node --check scripts/validate-local.mjs
           node --check scripts/audit-production.mjs
@@ -75,6 +76,12 @@ jobs:
           node scripts/validate-artifact-privacy.mjs --dist-dir dist
       - name: Verify CyberDailyLog fallback is in the artifact
         run: test -s dist/assets/data/cyberdailylog-latest.json
+      - name: Verify stability assets are in the artifact
+        run: |
+          test -s dist/assets/js/stability-hotfix.js
+          test -s dist/assets/css/stability-hotfix.css
+          grep -Fq "stability-hotfix.js?v=${VITE_BUILD_VERSION}" dist/index.html
+          grep -Fq "stability-hotfix.css?v=${VITE_BUILD_VERSION}" dist/index.html
       - name: Verify tracked source stayed clean after build
         run: |
           git diff --exit-code
@@ -99,55 +106,43 @@ jobs:
             test-results/
           retention-days: 10
           if-no-files-found: ignore
-      - name: Upload tested deployment artifact
+      - name: Configure GitHub Pages artifact
         if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3 verified release
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5 verified release
+      - name: Upload tested GitHub Pages artifact
+        if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4 verified release
         with:
-          name: tested-pages-${{ steps.build_version.outputs.version }}
           path: dist
-          retention-days: 2
-          if-no-files-found: error
 
   deploy:
-    name: Publish tested artifact to gh-pages
+    name: Deploy tested artifact to GitHub Pages
     needs: qa
     if: ${{ needs.qa.result == 'success' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - name: Checkout repository with publication credentials
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7 verified release
-        with:
-          fetch-depth: 0
-          persist-credentials: true
-      - name: Download tested deployment artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0 verified release
-        with:
-          name: tested-pages-${{ needs.qa.outputs.build_version }}
-          path: ${{ runner.temp }}/tested-pages
-      - name: Verify downloaded artifact
+      - name: Select workflow-based Pages publishing
         env:
-          EXPECTED_VERSION: ${{ needs.qa.outputs.build_version }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          test -s "$RUNNER_TEMP/tested-pages/index.html"
-          test -s "$RUNNER_TEMP/tested-pages/assets/data/cyberdailylog-latest.json"
-          grep -Fq "<meta name=\"build-version\" content=\"$EXPECTED_VERSION\"" "$RUNNER_TEMP/tested-pages/index.html"
-      - name: Publish immutable tested files to gh-pages
-        env:
-          BUILD_VERSION: ${{ needs.qa.outputs.build_version }}
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout --orphan gh-pages-publish
-          git rm -rf .
-          cp -a "$RUNNER_TEMP/tested-pages/." .
-          touch .nojekyll
-          git add -A
-          git commit -m "deploy: publish tested portfolio ${BUILD_VERSION}"
-          git push --force origin HEAD:gh-pages
+          curl --fail-with-body --silent --show-error \
+            --request PUT \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer ${GH_TOKEN}" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/pages" \
+            --data '{"build_type":"workflow"}'
+      - name: Deploy tested Pages artifact
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4 verified release
 
   production-audit:
     name: Production audit

--- a/.github/workflows/site-qa-pages.yml
+++ b/.github/workflows/site-qa-pages.yml
@@ -106,9 +106,6 @@ jobs:
             test-results/
           retention-days: 10
           if-no-files-found: ignore
-      - name: Configure GitHub Pages artifact
-        if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5 verified release
       - name: Upload tested GitHub Pages artifact
         if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4 verified release

--- a/assets/css/stability-hotfix.css
+++ b/assets/css/stability-hotfix.css
@@ -1,0 +1,78 @@
+@media (min-width: 1025px) {
+  .contacts-list {
+    flex: 0 0 auto;
+    max-height: none !important;
+    overflow: visible !important;
+  }
+
+  .contact-item {
+    width: 100%;
+    min-width: 0;
+    align-items: flex-start;
+  }
+
+  .contact-info {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .contact-info .contact-link,
+  .contact-info address {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .navbar {
+    min-height: 88px;
+  }
+}
+
+/* Browser zoom reduces the effective CSS-pixel viewport height. At short
+   desktop heights the avatar is lower-value than readable contact details and
+   navigation, so remove it before either of those areas can be clipped. */
+@media (min-width: 1025px) and (max-height: 620px) {
+  .sidebar {
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+
+  .avatar-bg {
+    display: none !important;
+  }
+
+  .main-name {
+    margin: 2px 0;
+    font-size: 1.05rem;
+    line-height: 1.2;
+  }
+
+  .title {
+    margin: 0 0 5px;
+    font-size: 0.76rem;
+    line-height: 1.25;
+  }
+
+  .sidebar-info > .separator {
+    margin: 5px 0;
+  }
+
+  .contact-item {
+    padding-top: 2px;
+    padding-bottom: 2px;
+  }
+
+  .contact-title,
+  .contact-link,
+  .contact-info address {
+    font-size: 0.72rem;
+    line-height: 1.25;
+  }
+
+  .navbar {
+    min-height: 112px;
+  }
+}

--- a/assets/js/stability-hotfix.js
+++ b/assets/js/stability-hotfix.js
@@ -1,0 +1,83 @@
+const CONSENT_STORAGE_KEY = 'consent-analytics';
+
+function readConsentPreference() {
+  try {
+    return window.localStorage.getItem(CONSENT_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function saveConsentPreference(value) {
+  try {
+    window.localStorage.setItem(CONSENT_STORAGE_KEY, value);
+  } catch {
+    // Storage can be unavailable in strict privacy modes. Consent dismissal
+    // must still work for the current page even when the choice cannot persist.
+  }
+}
+
+function initializeStableConsent() {
+  const banner = document.getElementById('consent');
+  if (!banner || banner.dataset.stableConsent === 'ready') return;
+
+  banner.dataset.stableConsent = 'ready';
+  let dismissed = false;
+
+  const resetConsentOffset = () => {
+    document.documentElement.style.setProperty('--scroll-top-consent-offset', '0px');
+  };
+
+  const dismiss = value => {
+    if (dismissed) return;
+    dismissed = true;
+
+    // Hide first so the UI responds immediately, independently of storage or
+    // analytics availability.
+    banner.hidden = true;
+    banner.setAttribute('aria-hidden', 'true');
+    resetConsentOffset();
+    saveConsentPreference(value);
+
+    if (value === 'yes' && typeof window.plausible === 'function') {
+      try {
+        window.plausible('pageview');
+      } catch {
+        // Analytics must never block the consent interaction.
+      }
+    }
+
+    banner.remove();
+  };
+
+  const handleConsent = event => {
+    const target = event.target instanceof Element
+      ? event.target.closest('#consent-accept, #consent-decline')
+      : null;
+    if (!target) return;
+
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    dismiss(target.id === 'consent-accept' ? 'yes' : 'no');
+  };
+
+  const prior = readConsentPreference();
+  if (prior === 'yes' || prior === 'no') {
+    dismiss(prior);
+    return;
+  }
+
+  banner.hidden = false;
+  banner.removeAttribute('aria-hidden');
+
+  // Capture-phase handlers take precedence over legacy delegated listeners and
+  // guarantee a single deterministic action for pointer, mouse and keyboard use.
+  document.addEventListener('pointerup', handleConsent, { capture: true, passive: false });
+  document.addEventListener('click', handleConsent, { capture: true, passive: false });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initializeStableConsent, { once: true });
+} else {
+  initializeStableConsent();
+}

--- a/assets/js/stability-hotfix.js
+++ b/assets/js/stability-hotfix.js
@@ -51,7 +51,7 @@ function initializeStableConsent() {
   };
 
   const handleConsent = event => {
-    const target = event.target instanceof Element
+    const target = event.target?.closest
       ? event.target.closest('#consent-accept, #consent-decline')
       : null;
     if (!target) return;

--- a/tests/stability-hotfix.spec.js
+++ b/tests/stability-hotfix.spec.js
@@ -1,0 +1,92 @@
+import { test, expect } from '@playwright/test';
+import { openHome } from './helpers';
+
+const CONSENT_KEY = 'consent-analytics';
+
+test('consent banner dismisses in one click when localStorage writes are blocked', async ({ page }) => {
+  await page.addInitScript(key => {
+    window.localStorage.removeItem(key);
+    const originalSetItem = Storage.prototype.setItem;
+    Storage.prototype.setItem = function setItem(name, value) {
+      if (name === key) throw new DOMException('Storage blocked for QA', 'SecurityError');
+      return originalSetItem.call(this, name, value);
+    };
+  }, CONSENT_KEY);
+
+  const guard = await openHome(page);
+  const consent = page.locator('#consent');
+
+  await expect(consent).toBeVisible();
+  await page.locator('#consent-decline').click();
+  await expect(consent).toBeHidden();
+  await expect(page.getByRole('main')).toBeVisible();
+
+  guard.assertNoSameOriginFailures();
+  guard.assertNoPageErrors();
+});
+
+test('accepting analytics dismisses the banner and persists the preference', async ({ page }) => {
+  await page.addInitScript(key => window.localStorage.removeItem(key), CONSENT_KEY);
+
+  const guard = await openHome(page);
+  const consent = page.locator('#consent');
+
+  await expect(consent).toBeVisible();
+  await page.locator('#consent-accept').click();
+  await expect(consent).toBeHidden();
+  await expect.poll(() => page.evaluate(key => window.localStorage.getItem(key), CONSENT_KEY)).toBe('yes');
+
+  guard.assertNoSameOriginFailures();
+  guard.assertNoPageErrors();
+});
+
+test('short desktop view keeps all contact text and navigation inside the sidebar', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 600 });
+  const guard = await openHome(page);
+
+  const sidebar = page.locator('.sidebar');
+  const contacts = page.locator('.contacts-list');
+  const nav = page.locator('.navbar');
+
+  await expect(sidebar).toBeVisible();
+  await expect(page.locator('.avatar-bg')).toBeHidden();
+  await expect(contacts).toBeVisible();
+  await expect(nav).toBeVisible();
+
+  const geometry = await page.evaluate(() => {
+    const sidebarRect = document.querySelector('.sidebar').getBoundingClientRect();
+    const contactsRect = document.querySelector('.contacts-list').getBoundingClientRect();
+    const navRect = document.querySelector('.navbar').getBoundingClientRect();
+    const contactRows = Array.from(document.querySelectorAll('.contact-item')).map(row => {
+      const rect = row.getBoundingClientRect();
+      const text = row.querySelector('.contact-info')?.innerText.trim() || '';
+      return { top: rect.top, bottom: rect.bottom, left: rect.left, right: rect.right, text };
+    });
+
+    return {
+      sidebar: { top: sidebarRect.top, bottom: sidebarRect.bottom, left: sidebarRect.left, right: sidebarRect.right },
+      contacts: { top: contactsRect.top, bottom: contactsRect.bottom },
+      nav: { top: navRect.top, bottom: navRect.bottom, height: navRect.height },
+      contactRows,
+      horizontalOverflow: document.documentElement.scrollWidth - document.documentElement.clientWidth
+    };
+  });
+
+  expect(geometry.horizontalOverflow).toBeLessThanOrEqual(2);
+  expect(geometry.contacts.top).toBeGreaterThanOrEqual(geometry.sidebar.top - 1);
+  expect(geometry.contacts.bottom).toBeLessThanOrEqual(geometry.sidebar.bottom + 1);
+  expect(geometry.nav.top).toBeGreaterThanOrEqual(geometry.contacts.bottom - 1);
+  expect(geometry.nav.bottom).toBeLessThanOrEqual(geometry.sidebar.bottom + 1);
+  expect(geometry.nav.height).toBeGreaterThanOrEqual(88);
+
+  for (const row of geometry.contactRows) {
+    expect(row.text.length).toBeGreaterThan(0);
+    expect(row.left).toBeGreaterThanOrEqual(geometry.sidebar.left - 1);
+    expect(row.right).toBeLessThanOrEqual(geometry.sidebar.right + 1);
+    expect(row.top).toBeGreaterThanOrEqual(geometry.sidebar.top - 1);
+    expect(row.bottom).toBeLessThanOrEqual(geometry.sidebar.bottom + 1);
+  }
+
+  guard.assertNoSameOriginFailures();
+  guard.assertNoPageErrors();
+});

--- a/tests/stability-hotfix.spec.js
+++ b/tests/stability-hotfix.spec.js
@@ -6,9 +6,9 @@ const CONSENT_KEY = 'consent-analytics';
 test('consent banner dismisses in one click when localStorage writes are blocked', async ({ page }) => {
   await page.addInitScript(key => {
     window.localStorage.removeItem(key);
-    const originalSetItem = Storage.prototype.setItem;
-    Storage.prototype.setItem = function setItem(name, value) {
-      if (name === key) throw new DOMException('Storage blocked for QA', 'SecurityError');
+    const originalSetItem = window.Storage.prototype.setItem;
+    window.Storage.prototype.setItem = function setItem(name, value) {
+      if (name === key) throw new window.DOMException('Storage blocked for QA', 'SecurityError');
       return originalSetItem.call(this, name, value);
     };
   }, CONSENT_KEY);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vite';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 
+const buildVersion = process.env.VITE_BUILD_VERSION || 'dev';
+
 const hardenGeneratedHtml = {
   name: 'harden-generated-html',
   enforce: 'post',
@@ -10,9 +12,21 @@ const hardenGeneratedHtml = {
       "script-src 'self' https://unpkg.com https://cdn.jsdelivr.net https://plausible.io;"
     );
 
-    return withPlausibleCsp.replace(
+    const withStabilityStyles = withPlausibleCsp.replace(
       '</head>',
-      ['  <link rel="stylesheet" href="./assets/css/qa-fixes.css">', '</head>'].join('\n')
+      [
+        '  <link rel="stylesheet" href="./assets/css/qa-fixes.css">',
+        `  <link rel="stylesheet" href="./assets/css/stability-hotfix.css?v=${buildVersion}">`,
+        '</head>'
+      ].join('\n')
+    );
+
+    return withStabilityStyles.replace(
+      '</body>',
+      [
+        `  <script type="module" src="./assets/js/stability-hotfix.js?v=${buildVersion}"></script>`,
+        '</body>'
+      ].join('\n')
     );
   }
 };


### PR DESCRIPTION
## Problem

The tested Vite artifact was being force-pushed to `gh-pages` with `GITHUB_TOKEN`, but GitHub does not trigger a Pages build for commits created by that token. As a result, the public URL could continue serving an older portfolio even though `gh-pages` contained the newer build.

Two runtime robustness issues were also identified:

- consent dismissal depended on a successful `localStorage.setItem`, so strict privacy/storage modes could leave the banner open;
- desktop contact details could be clipped at short effective viewport heights or browser zoom because the sidebar and contacts list used hidden overflow.

## Changes

- Deploy the exact tested `dist` artifact through the official GitHub Pages artifact/deployment API.
- Switch the Pages site to workflow-based publishing in the deploy job with `pages: write` and `id-token: write` permissions.
- Preserve the existing QA gates before any production deployment.
- Add a consent stability layer that hides the banner immediately and treats persistence/analytics as best-effort operations.
- Add wrapping and short-height desktop rules so email, location, CV and navigation remain readable.
- Version the new CSS/JS stability assets with the canonical build SHA.
- Add Playwright regressions for blocked storage, accept persistence and a 1280×600 desktop sidebar.

## Validation expected

The PR run must pass dependency installation, syntax, lint, build, generated-output validation, privacy checks, Chromium Playwright, Axe, responsive QA and source cleanliness. Deployment remains skipped on the pull-request event. After merge, the main run must additionally pass Pages deployment and the production audit against the exact new build version.

No direct changes were made to `main` or `gh-pages`.