### PR TITLE
Update portfolio copyright year

### DIFF
--- a/index.html
+++ b/index.html
@@ -401,7 +401,7 @@
 
 <footer role="contentinfo" class="site-footer">
   <div class="site-footer-row">
-    <small>© 2025 Jaime Ramsden de Frutos · <a href="LICENSE" class="footer-link">MIT License</a></small>
+    <small>© 2025–2026 Jaime Ramsden de Frutos · <a href="LICENSE" class="footer-link">MIT License</a></small>
     <a href="https://pages.github.com/" target="_blank" rel="noopener" class="footer-link">Powered by GitHub Pages</a>
   </div>
   <div class="site-footer-source">View source on <a href="https://github.com/JimBLogic/jimblogic.github.io" target="_blank" rel="noopener" class="footer-link">GitHub</a></div>


### PR DESCRIPTION
Superseded by #42, which consolidates this change on the current `main` together with the related recruiter-facing updates. The original PR remains available for traceability.