### PR TITLE
Add Threat Modeling evidence

### DIFF
--- a/certificates.json
+++ b/certificates.json
@@ -11,6 +11,7 @@
   { "name": "Security Operations", "issuer": "Cybrary", "badgeLocal": "cybrary/cybrary-cert-security-security-operations.png", "link": "./assets/pdfs/cybrary/cybrary-cert-security-security-operations.pdf" },
   { "name": "Security Program Management and Oversight", "issuer": "Cybrary", "badgeLocal": "cybrary/cybrary-cert-security-security-program-management-and-oversight.png", "link": "./assets/pdfs/cybrary/cybrary-cert-security-security-program-management-and-oversight.pdf" },
   { "name": "Threats, Vulnerabilities, and Mitigations", "issuer": "Cybrary", "badgeLocal": "cybrary/cybrary-cert-security-threats-vulnerabilities-and-mitigations.png", "link": "./assets/pdfs/cybrary/cybrary-cert-security-threats-vulnerabilities-and-mitigations.pdf" },
+  { "name": "Threat Modeling", "issuer": "Cybrary", "badgeWeb": "./assets/Images/Profilepicandother/cybrary.jpg", "badgeLocal": "", "link": "https://github.com/JimBLogic/Cybrary-IT-Cybersecurity-Certificates-and-Labs/blob/main/Certificates/cybrary-cert-threat-modeling.pdf" },
   { "name": "Vulnerability Scanner Basics", "issuer": "Cybrary", "badgeLocal": "cybrary/cybrary-cert-vulnerability-scanner-basics.png", "link": "./assets/pdfs/cybrary/cybrary-cert-vulnerability-scanner-basics.pdf" },
   { "name": "Welcome to Cybrary", "issuer": "Cybrary", "badgeLocal": "cybrary/cybrary-cert-welcome-to-cybrary.png", "link": "./assets/pdfs/cybrary/cybrary-cert-welcome-to-cybrary.pdf" },
 


### PR DESCRIPTION
Superseded by #42, which consolidates this change on the current `main` together with the related recruiter-facing updates. The original PR remains available for traceability.