### PR TITLE
Link Credly from certificate evidence

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,7 +224,8 @@
         <a href="https://github.com/JimBLogic/Security-Blue-Team-Learning-Journey-Certificates" target="_blank" rel="noopener noreferrer">Security Blue Team</a>,
         <a href="https://github.com/JimBLogic/Cybrary-IT-Cybersecurity-Certificates-and-Labs" target="_blank" rel="noopener noreferrer">Cybrary</a>,
         <a href="https://github.com/JimBLogic/AWS-IBM-Skills-Build-KCCS-Moss-Cibersecurity-Institute" target="_blank" rel="noopener noreferrer">AWS · IBM Skills Build · MCSI</a>,
-        <a href="https://github.com/JimBLogic/TryHackme-HackTheBox" target="_blank" rel="noopener noreferrer">TryHackMe · HackTheBox</a>.
+        <a href="https://github.com/JimBLogic/TryHackme-HackTheBox" target="_blank" rel="noopener noreferrer">TryHackMe · HackTheBox</a>,
+        <a href="https://www.credly.com/users/jaime-ramsden/badges/credly" target="_blank" rel="noopener noreferrer">verified Credly badges</a>.
       </p>
     </section>
 


### PR DESCRIPTION
## Summary
- add Jaime's public Credly portfolio to the existing learning-journeys and certificate-evidence links
- keep Credly out of the social/contact area and primary hero actions

## Why
The link is presented where recruiters are already reviewing certificate evidence, so its purpose is verification rather than social networking.

## Validation
- confirmed the public Credly profile contains Jaime's four visible badges
- confirmed the URL appears exactly once in `index.html`
- preserved `target="_blank"` and `rel="noopener noreferrer"`
- branch is one commit ahead and zero commits behind `main`