### PR TITLE
Consolidate recruiter-facing portfolio evidence

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -90,7 +90,7 @@ function buildCertFilters() {
   if (!filterEl || !Array.isArray(CERT_DATA)) return;
   const issuers = Array.from(new Set(CERT_DATA.map(c => c.issuer).filter(Boolean)));
   const shortNames = { 'Mossé Cyber Security Institute': 'MCSI' };
-  const order = ['ALL', 'Security Blue Team', 'Cybrary', 'AWS', 'IBM', 'Mossé Cyber Security Institute', 'UpgradeHub'];
+  const order = ['ALL', 'Security Blue Team', 'Cybrary', 'AWS', 'IBM', 'Cisco', 'Mossé Cyber Security Institute', 'UpgradeHub'];
   const btns = order.filter(x => x === 'ALL' || issuers.includes(x)).map(key => {
     const label = key === 'ALL' ? t('filter_all') : (shortNames[key] || key);
     return `<button class="filter-btn" data-filter="${key}">${label}</button>`;
@@ -151,7 +151,7 @@ function renderLearningJourney(gridId) {
       key: 'Mossé Cyber Security Institute',
       name: 'MCSI',
       imgWeb: 'https://img.icons8.com/fluency/48/security-checked.png',
-      link: 'https://www.mosse-institute.com/knowledge-tests/kccs-knowledge-of-cybersecurity-skills.html'
+      link: 'https://students.mosse-institute.com/knowledge-test/CwLmPjf2GImtJzeszhxJ'
     },
     {
       key: 'UpgradeHub',
@@ -530,8 +530,19 @@ function renderGitHubProjects(username, listId) {
     .then(r => { if (!r.ok) throw new Error(`GitHub repositories failed: ${r.status}`); return r.json(); })
     .then(list => {
       if (!Array.isArray(list)) throw new Error('Invalid GitHub repositories payload');
-      // Filter only original repos (non-forks)
-      const nonFork = list.filter(r => r && r.fork === false);
+      // Keep the recruiter view focused on original, portfolio-relevant work.
+      const excludedRepos = new Set([
+        'github-slideshow',
+        'hello-world',
+        'jimblogic',
+        'jimblogic.github.io',
+        'projects',
+        'skills-communicate-using-markdown',
+        'skills-introduction-to-github'
+      ]);
+      const nonFork = list.filter(r =>
+        r && r.fork === false && !excludedRepos.has((r.name || '').toLowerCase())
+      );
       // Compute latest updated repo from the full non-fork list
       const latestUpdated = nonFork.slice().sort((a, b) => new Date(b.updated_at) - new Date(a.updated_at))[0] || null;
       // Build display list (top by stars, then updated), limit to 12
@@ -563,10 +574,10 @@ const MANUAL_PROJECTS = [
   {
     html_url: 'https://github.com/JimBLogic/CyberDailyLog',
     name: 'CyberDailyLog',
-    description: 'Personal cyber-security habit tracker with automated daily-intel reports, CSV validation, pre-commit hooks, and CI. Stores daily-log CSV, news-scan markdown, and automation scripts.',
-    language: 'PowerShell / Python',
+    description: 'Automated, source-backed 24-hour Blue Team intelligence pipeline with source-health validation, deterministic prioritisation, reproducible daily reports, and a compact public portfolio feed.',
+    language: 'Python',
     stargazers_count: 0,
-    topics: ['daily-log','csv-validation','automation','cybersecurity','github-actions'],
+    topics: ['blue-team','threat-intelligence','automation','cybersecurity','github-actions'],
     owner: { avatar_url: 'https://github.com/JimBLogic.png' }
   }
 ];

--- a/certificates.json
+++ b/certificates.json
@@ -1,37 +1,237 @@
 [
-  
-  { "name": "Access Control Basics", "issuer": "Cybrary", "badgeLocal": "cybrary/cybrary-cert-access-control-basics.png", "link": "./assets/pdfs/cybrary/cybrary-cert-access-control-basics.pdf" },
-  { "name": "Cryptography Basics", "issuer": "Cybrary", "badgeLocal": "cybrary/cybrary-cert-cryptography-basics.png", "link": "./assets/pdfs/cybrary/cybrary-cert-cryptography-basics.pdf" },
-  { "name": "Firewall Basics", "issuer": "Cybrary", "badgeLocal": "cybrary/cybrary-cert-firewall-basics.png", "link": "./assets/pdfs/cybrary/cybrary-cert-firewall-basics.pdf" },
-  { "name": "Group Policy Basics", "issuer": "Cybrary", "badgeLocal": "cybrary/cybrary-cert-group-policy-basics.png", "link": "./assets/pdfs/cybrary/cybrary-cert-group-policy-basics.pdf" },
-  { "name": "IP Addressing Basics", "issuer": "Cybrary", "badgeLocal": "cybrary/cybrary-cert-ip-addressing-basics.png", "link": "./assets/pdfs/cybrary/cybrary-cert-ip-addressing-basics.pdf" },
-  { "name": "Patching Basics", "issuer": "Cybrary", "badgeLocal": "cybrary/cybrary-cert-patching-basics.png", "link": "./assets/pdfs/cybrary/cybrary-cert-patching-basics.pdf" },
-  { "name": "General Security Concepts", "issuer": "Cybrary", "badgeLocal": "cybrary/cybrary-cert-security-general-security-concepts.png", "link": "./assets/pdfs/cybrary/cybrary-cert-security-general-security-concepts.pdf" },
-  { "name": "Security Architecture", "issuer": "Cybrary", "badgeLocal": "cybrary/cybrary-cert-security-security-architecture.png", "link": "./assets/pdfs/cybrary/cybrary-cert-security-security-architecture.pdf" },
-  { "name": "Security Operations", "issuer": "Cybrary", "badgeLocal": "cybrary/cybrary-cert-security-security-operations.png", "link": "./assets/pdfs/cybrary/cybrary-cert-security-security-operations.pdf" },
-  { "name": "Security Program Management and Oversight", "issuer": "Cybrary", "badgeLocal": "cybrary/cybrary-cert-security-security-program-management-and-oversight.png", "link": "./assets/pdfs/cybrary/cybrary-cert-security-security-program-management-and-oversight.pdf" },
-  { "name": "Threats, Vulnerabilities, and Mitigations", "issuer": "Cybrary", "badgeLocal": "cybrary/cybrary-cert-security-threats-vulnerabilities-and-mitigations.png", "link": "./assets/pdfs/cybrary/cybrary-cert-security-threats-vulnerabilities-and-mitigations.pdf" },
-  { "name": "Vulnerability Scanner Basics", "issuer": "Cybrary", "badgeLocal": "cybrary/cybrary-cert-vulnerability-scanner-basics.png", "link": "./assets/pdfs/cybrary/cybrary-cert-vulnerability-scanner-basics.pdf" },
-  { "name": "Welcome to Cybrary", "issuer": "Cybrary", "badgeLocal": "cybrary/cybrary-cert-welcome-to-cybrary.png", "link": "./assets/pdfs/cybrary/cybrary-cert-welcome-to-cybrary.pdf" },
-
-  { "name": "Blue Team Junior Analyst Pathway Bundle", "issuer": "Security Blue Team", "badgeLocal": "SecurityBlueTeam/Blue Team Junior Analyst Pathway Bundle-btja.png", "link": "./assets/pdfs/SecurityBlueTeam/Blue Team Junior Analyst Pathway Bundle-btja.pdf" },
-  { "name": "Introduction to Dark Web Operations", "issuer": "Security Blue Team", "badgeLocal": "SecurityBlueTeam/Introduction to Dark Web Operations-course.png", "link": "./assets/pdfs/SecurityBlueTeam/Introduction to Dark Web Operations-course.pdf" },
-  { "name": "Introduction to Digital Forensics", "issuer": "Security Blue Team", "badgeLocal": "SecurityBlueTeam/Introduction to Digital Forensics-course.png", "link": "./assets/pdfs/SecurityBlueTeam/Introduction to Digital Forensics-course.pdf" },
-  { "name": "Introduction to Network Analysis", "issuer": "Security Blue Team", "badgeLocal": "SecurityBlueTeam/Introduction to Network Analysis-course.jpg", "link": "./assets/pdfs/SecurityBlueTeam/Introduction to Network Analysis-course.pdf" },
-  { "name": "Introduction to OSINT", "issuer": "Security Blue Team", "badgeLocal": "SecurityBlueTeam/Introduction to OSINT-course.png", "link": "./assets/pdfs/SecurityBlueTeam/Introduction to OSINT-course.pdf" },
-  { "name": "Introduction to PowerShell", "issuer": "Security Blue Team", "badgeLocal": "SecurityBlueTeam/Introduction to PowerShell-course.png", "link": "./assets/pdfs/SecurityBlueTeam/Introduction to PowerShell-course.pdf" },
-  { "name": "Introduction to Python", "issuer": "Security Blue Team", "badgeLocal": "SecurityBlueTeam/Introduction to Python.PNG", "link": "./assets/pdfs/SecurityBlueTeam/Introduction to Python-course.pdf" },
-  { "name": "Introduction to Threat Hunting", "issuer": "Security Blue Team", "badgeLocal": "SecurityBlueTeam/Introduction to Threat Hunting-course.png", "link": "./assets/pdfs/SecurityBlueTeam/Introduction to Threat Hunting-course.pdf" },
-  { "name": "Introduction to Virtual Machines", "issuer": "Security Blue Team", "badgeLocal": "SecurityBlueTeam/Introduction to Virtual Machines-course.jpg", "link": "./assets/pdfs/SecurityBlueTeam/Introduction to Virtual Machines-course.pdf" },
-  { "name": "Introduction to Vulnerability Management", "issuer": "Security Blue Team", "badgeLocal": "SecurityBlueTeam/Introduction to Vulnerability Management-course.png", "link": "./assets/pdfs/SecurityBlueTeam/Introduction to Vulnerability Management-course.pdf" },
-  { "name": "Mental Health in Cybersecurity", "issuer": "Security Blue Team", "badgeLocal": "SecurityBlueTeam/Mental Health in Cybersecurity-course.png", "link": "./assets/pdfs/SecurityBlueTeam/Mental Health in Cybersecurity-course.pdf" },
-
-  { "name": "KCCS - Knowledge of Cybersecurity Skills", "issuer": "Mossé Cyber Security Institute", "badgeLocal": "MosseCyberSecurityInstitute/KCCS - Knowledge of Cybersecurity Skills.png", "link": "https://www.mosse-institute.com/knowledge-tests/kccs-knowledge-of-cybersecurity-skills.html" },
-
-  { "name": "AWS Course Completion Certificate", "issuer": "AWS", "badgeWeb": "https://cdn.jsdelivr.net/npm/simple-icons@v11/icons/amazonaws.svg", "badgeLocal": "", "link": "./assets/pdfs/aws/156_3_6860342_1735817985_AWS%20Course%20Completion%20Certificate.pdf" },
-  { "name": "AWS Skill Builder Course Completion Certificate", "issuer": "AWS", "badgeWeb": "https://cdn.jsdelivr.net/npm/simple-icons@v11/icons/amazonaws.svg", "badgeLocal": "", "link": "./assets/pdfs/aws/18443_5_6860342_1735810643_AWS%20Skill%20Builder%20Course%20Completion%20Certificate.pdf" },
-
-  { "name": "Python 60h", "issuer": "IBM", "badgeWeb": "https://cdn.jsdelivr.net/npm/simple-icons@v11/icons/ibm.svg", "badgeLocal": "", "link": "./assets/pdfs/IBM/python%2060h.pdf" },
-
-  { "name": "Cybersecurity Bootcamp (UpgradeHub)", "issuer": "UpgradeHub", "badgeWeb": "https://cdn.jsdelivr.net/npm/simple-icons@v11/icons/graduated.svg", "badgeLocal": "", "link": "./assets/pdfs/UpgradeHub/UpgradeHub Cert.pdf" }
+  {
+    "name": "Access Control Basics",
+    "issuer": "Cybrary",
+    "badgeLocal": "cybrary/cybrary-cert-access-control-basics.png",
+    "link": "./assets/pdfs/cybrary/cybrary-cert-access-control-basics.pdf"
+  },
+  {
+    "name": "Cryptography Basics",
+    "issuer": "Cybrary",
+    "badgeLocal": "cybrary/cybrary-cert-cryptography-basics.png",
+    "link": "./assets/pdfs/cybrary/cybrary-cert-cryptography-basics.pdf"
+  },
+  {
+    "name": "Firewall Basics",
+    "issuer": "Cybrary",
+    "badgeLocal": "cybrary/cybrary-cert-firewall-basics.png",
+    "link": "./assets/pdfs/cybrary/cybrary-cert-firewall-basics.pdf"
+  },
+  {
+    "name": "Group Policy Basics",
+    "issuer": "Cybrary",
+    "badgeLocal": "cybrary/cybrary-cert-group-policy-basics.png",
+    "link": "./assets/pdfs/cybrary/cybrary-cert-group-policy-basics.pdf"
+  },
+  {
+    "name": "IP Addressing Basics",
+    "issuer": "Cybrary",
+    "badgeLocal": "cybrary/cybrary-cert-ip-addressing-basics.png",
+    "link": "./assets/pdfs/cybrary/cybrary-cert-ip-addressing-basics.pdf"
+  },
+  {
+    "name": "Patching Basics",
+    "issuer": "Cybrary",
+    "badgeLocal": "cybrary/cybrary-cert-patching-basics.png",
+    "link": "./assets/pdfs/cybrary/cybrary-cert-patching-basics.pdf"
+  },
+  {
+    "name": "General Security Concepts",
+    "issuer": "Cybrary",
+    "badgeLocal": "cybrary/cybrary-cert-security-general-security-concepts.png",
+    "link": "./assets/pdfs/cybrary/cybrary-cert-security-general-security-concepts.pdf"
+  },
+  {
+    "name": "Security Architecture",
+    "issuer": "Cybrary",
+    "badgeLocal": "cybrary/cybrary-cert-security-security-architecture.png",
+    "link": "./assets/pdfs/cybrary/cybrary-cert-security-security-architecture.pdf"
+  },
+  {
+    "name": "Security Operations",
+    "issuer": "Cybrary",
+    "badgeLocal": "cybrary/cybrary-cert-security-security-operations.png",
+    "link": "./assets/pdfs/cybrary/cybrary-cert-security-security-operations.pdf"
+  },
+  {
+    "name": "Security Program Management and Oversight",
+    "issuer": "Cybrary",
+    "badgeLocal": "cybrary/cybrary-cert-security-security-program-management-and-oversight.png",
+    "link": "./assets/pdfs/cybrary/cybrary-cert-security-security-program-management-and-oversight.pdf"
+  },
+  {
+    "name": "Threats, Vulnerabilities, and Mitigations",
+    "issuer": "Cybrary",
+    "badgeLocal": "cybrary/cybrary-cert-security-threats-vulnerabilities-and-mitigations.png",
+    "link": "./assets/pdfs/cybrary/cybrary-cert-security-threats-vulnerabilities-and-mitigations.pdf"
+  },
+  {
+    "name": "Vulnerability Scanner Basics",
+    "issuer": "Cybrary",
+    "badgeLocal": "cybrary/cybrary-cert-vulnerability-scanner-basics.png",
+    "link": "./assets/pdfs/cybrary/cybrary-cert-vulnerability-scanner-basics.pdf"
+  },
+  {
+    "name": "Blue Team Junior Analyst Pathway Bundle",
+    "issuer": "Security Blue Team",
+    "badgeLocal": "SecurityBlueTeam/Blue Team Junior Analyst Pathway Bundle-btja.png",
+    "link": "./assets/pdfs/SecurityBlueTeam/Blue Team Junior Analyst Pathway Bundle-btja.pdf"
+  },
+  {
+    "name": "Introduction to Dark Web Operations",
+    "issuer": "Security Blue Team",
+    "badgeLocal": "SecurityBlueTeam/Introduction to Dark Web Operations-course.png",
+    "link": "./assets/pdfs/SecurityBlueTeam/Introduction to Dark Web Operations-course.pdf"
+  },
+  {
+    "name": "Introduction to Digital Forensics",
+    "issuer": "Security Blue Team",
+    "badgeLocal": "SecurityBlueTeam/Introduction to Digital Forensics-course.png",
+    "link": "./assets/pdfs/SecurityBlueTeam/Introduction to Digital Forensics-course.pdf"
+  },
+  {
+    "name": "Introduction to Network Analysis",
+    "issuer": "Security Blue Team",
+    "badgeLocal": "SecurityBlueTeam/Introduction to Network Analysis-course.jpg",
+    "link": "./assets/pdfs/SecurityBlueTeam/Introduction to Network Analysis-course.pdf"
+  },
+  {
+    "name": "Introduction to OSINT",
+    "issuer": "Security Blue Team",
+    "badgeLocal": "SecurityBlueTeam/Introduction to OSINT-course.png",
+    "link": "./assets/pdfs/SecurityBlueTeam/Introduction to OSINT-course.pdf"
+  },
+  {
+    "name": "Introduction to PowerShell",
+    "issuer": "Security Blue Team",
+    "badgeLocal": "SecurityBlueTeam/Introduction to PowerShell-course.png",
+    "link": "./assets/pdfs/SecurityBlueTeam/Introduction to PowerShell-course.pdf"
+  },
+  {
+    "name": "Introduction to Python",
+    "issuer": "Security Blue Team",
+    "badgeLocal": "SecurityBlueTeam/Introduction to Python.PNG",
+    "link": "./assets/pdfs/SecurityBlueTeam/Introduction to Python-course.pdf"
+  },
+  {
+    "name": "Introduction to Threat Hunting",
+    "issuer": "Security Blue Team",
+    "badgeLocal": "SecurityBlueTeam/Introduction to Threat Hunting-course.png",
+    "link": "./assets/pdfs/SecurityBlueTeam/Introduction to Threat Hunting-course.pdf"
+  },
+  {
+    "name": "Introduction to Virtual Machines",
+    "issuer": "Security Blue Team",
+    "badgeLocal": "SecurityBlueTeam/Introduction to Virtual Machines-course.jpg",
+    "link": "./assets/pdfs/SecurityBlueTeam/Introduction to Virtual Machines-course.pdf"
+  },
+  {
+    "name": "Introduction to Vulnerability Management",
+    "issuer": "Security Blue Team",
+    "badgeLocal": "SecurityBlueTeam/Introduction to Vulnerability Management-course.png",
+    "link": "./assets/pdfs/SecurityBlueTeam/Introduction to Vulnerability Management-course.pdf"
+  },
+  {
+    "name": "Mental Health in Cybersecurity",
+    "issuer": "Security Blue Team",
+    "badgeLocal": "SecurityBlueTeam/Mental Health in Cybersecurity-course.png",
+    "link": "./assets/pdfs/SecurityBlueTeam/Mental Health in Cybersecurity-course.pdf"
+  },
+  {
+    "name": "KCCS - Knowledge of Cybersecurity Skills",
+    "issuer": "Mossé Cyber Security Institute",
+    "badgeLocal": "MosseCyberSecurityInstitute/KCCS - Knowledge of Cybersecurity Skills.png",
+    "link": "https://students.mosse-institute.com/knowledge-test/CwLmPjf2GImtJzeszhxJ"
+  },
+  {
+    "name": "AWS Course Completion Certificate",
+    "issuer": "AWS",
+    "badgeWeb": "https://cdn.jsdelivr.net/npm/simple-icons@v11/icons/amazonaws.svg",
+    "badgeLocal": "",
+    "link": "./assets/pdfs/aws/156_3_6860342_1735817985_AWS%20Course%20Completion%20Certificate.pdf"
+  },
+  {
+    "name": "AWS Skill Builder Course Completion Certificate",
+    "issuer": "AWS",
+    "badgeWeb": "https://cdn.jsdelivr.net/npm/simple-icons@v11/icons/amazonaws.svg",
+    "badgeLocal": "",
+    "link": "./assets/pdfs/aws/18443_5_6860342_1735810643_AWS%20Skill%20Builder%20Course%20Completion%20Certificate.pdf"
+  },
+  {
+    "name": "Python 60h",
+    "issuer": "IBM",
+    "badgeWeb": "https://cdn.jsdelivr.net/npm/simple-icons@v11/icons/ibm.svg",
+    "badgeLocal": "",
+    "link": "./assets/pdfs/IBM/python%2060h.pdf"
+  },
+  {
+    "name": "Cybersecurity Bootcamp (UpgradeHub)",
+    "issuer": "UpgradeHub",
+    "badgeWeb": "./UpgradeHub/upgradehubcert.png",
+    "badgeLocal": "",
+    "link": "./assets/pdfs/UpgradeHub/UpgradeHub Cert.pdf"
+  },
+  {
+    "name": "Introduction to Bash",
+    "issuer": "Security Blue Team",
+    "badgeWeb": "./assets/Images/Profilepicandother/blueteam.png",
+    "badgeLocal": "",
+    "link": "https://github.com/JimBLogic/Security-Blue-Team-Learning-Journey-Certificates/blob/main/certs/Introduction%20to%20Bash-course.pdf"
+  },
+  {
+    "name": "Defensive Security Operations",
+    "issuer": "Cybrary",
+    "badgeWeb": "./assets/Images/Profilepicandother/cybrary.jpg",
+    "badgeLocal": "",
+    "link": "https://github.com/JimBLogic/Cybrary-IT-Cybersecurity-Certificates-and-Labs/blob/main/Labs/cybrary-cert-defensive-security-operations.pdf"
+  },
+  {
+    "name": "Data Backup and Recovery Basics",
+    "issuer": "Cybrary",
+    "badgeWeb": "./assets/Images/Profilepicandother/cybrary.jpg",
+    "badgeLocal": "",
+    "link": "https://github.com/JimBLogic/Cybrary-IT-Cybersecurity-Certificates-and-Labs/blob/main/Certificates/cybrary-cert-data-backup-and-recovery.pdf"
+  },
+  {
+    "name": "Threat Modeling",
+    "issuer": "Cybrary",
+    "badgeWeb": "./assets/Images/Profilepicandother/cybrary.jpg",
+    "badgeLocal": "",
+    "link": "https://github.com/JimBLogic/Cybrary-IT-Cybersecurity-Certificates-and-Labs/blob/main/Certificates/cybrary-cert-threat-modeling.pdf"
+  },
+  {
+    "name": "Defensive Security and Cyber Risk",
+    "issuer": "Cybrary",
+    "badgeWeb": "./assets/Images/Profilepicandother/cybrary.jpg",
+    "badgeLocal": "",
+    "link": "https://github.com/JimBLogic/Cybrary-IT-Cybersecurity-Certificates-and-Labs/blob/main/Labs/cybrary-cert-defensive-security-and-cyber-risk.pdf"
+  },
+  {
+    "name": "AWS SimuLearn - Cloud Practitioner - Training Badge",
+    "issuer": "AWS",
+    "badgeWeb": "https://images.credly.com/images/b6b54bbe-b797-49a3-b571-58ca96328b9b/blob",
+    "badgeLocal": "",
+    "link": "https://www.credly.com/badges/2fbdc9ba-c4f6-4e34-bfe6-ada0751e536a"
+  },
+  {
+    "name": "Web Development with Python",
+    "issuer": "IBM",
+    "badgeWeb": "https://images.credly.com/images/1fb00135-23d3-42e9-a745-c7627e8a84bf/image.png",
+    "badgeLocal": "",
+    "link": "https://www.credly.com/badges/377ba6ff-0d4b-41df-8477-5ba08748c63d"
+  },
+  {
+    "name": "Cyber Threat Management",
+    "issuer": "Cisco",
+    "badgeWeb": "https://images.credly.com/images/5d5ac32b-d239-42b8-9665-8a921dc3ab47/image.png",
+    "badgeLocal": "",
+    "link": "https://www.credly.com/badges/5e2eb763-9d96-4f29-8018-99a71b82c352"
+  },
+  {
+    "name": "Introduction to Cybersecurity",
+    "issuer": "Cisco",
+    "badgeWeb": "https://images.credly.com/images/af8c6b4e-fc31-47c4-8dcb-eb7a2065dc5b/I2CS__1_.png",
+    "badgeLocal": "",
+    "link": "https://www.credly.com/badges/cf1cfdca-0fa3-4989-b065-46d985178ae2"
+  }
 ]

--- a/index.html
+++ b/index.html
@@ -401,7 +401,7 @@
 
 <footer role="contentinfo" class="site-footer">
   <div class="site-footer-row">
-    <small>© 2025 Jaime Ramsden de Frutos · <a href="LICENSE" class="footer-link">MIT License</a></small>
+    <small>© 2025–2026 Jaime Ramsden de Frutos · <a href="LICENSE" class="footer-link">MIT License</a></small>
     <a href="https://pages.github.com/" target="_blank" rel="noopener" class="footer-link">Powered by GitHub Pages</a>
   </div>
   <div class="site-footer-source">View source on <a href="https://github.com/JimBLogic/jimblogic.github.io" target="_blank" rel="noopener" class="footer-link">GitHub</a></div>


### PR DESCRIPTION
## Resultado

Consolida en una sola rama basada en el `main` actual las mejoras recruiter-facing que estaban repartidas entre 13 PR pequeños.

### Certificaciones
- Añade Introduction to Bash (Security Blue Team).
- Añade Defensive Security Operations, Data Backup and Recovery Basics, Threat Modeling y Defensive Security and Cyber Risk (Cybrary).
- Oculta el certificado introductorio "Welcome to Cybrary".
- Añade cuatro insignias públicas verificables: AWS SimuLearn, IBM Web Development with Python y dos Cisco.
- Usa la verificación personal de KCCS.
- Usa la imagen local de UpgradeHub.

### Portfolio
- Actualiza la tarjeta destacada de CyberDailyLog.
- Excluye repositorios de práctica/relleno del listado visible para recruiters.
- Añade Cisco al filtro de emisores.
- Enlaza el aprendizaje MCSI a la verificación personal.
- Actualiza el copyright a 2025–2026.

### Trazabilidad
Sustituye, sin perder el contexto, a #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #40 y #41.

### Validación completada
- ✅ Rama 3 commits por delante y 0 por detrás de `main`.
- ✅ JSON válido: 37 certificaciones y 0 nombres duplicados.
- ✅ 9 nuevas evidencias presentes; "Welcome to Cybrary" ausente.
- ✅ 4 enlaces Credly únicos y verificables.
- ✅ JavaScript analizado correctamente.
- ✅ Filtros, tarjeta de CyberDailyLog, enlaces personales y copyright comprobados.
- ✅ GitHub Actions **Site QA and Pages #70** completado con éxito.
