### PR TITLE
Restore recruiter UX and stabilize mobile controls

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1455,17 +1455,48 @@ a:hover {
   cursor: pointer;
   width: 44px;
   height: 44px;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .hamburger:hover {
   background: rgba(247, 147, 26, 0.25);
 }
 
+.menu-icon {
+  display: block;
+  width: 22px;
+  height: 16px;
+  position: relative;
+}
+
+.menu-icon span {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  border-radius: 2px;
+  background: currentColor;
+  transition: transform 0.2s ease, opacity 0.2s ease, top 0.2s ease;
+}
+
+.menu-icon span:nth-child(1) { top: 0; }
+.menu-icon span:nth-child(2) { top: 7px; }
+.menu-icon span:nth-child(3) { top: 14px; }
+.hamburger[aria-expanded="true"] .menu-icon span:nth-child(1) { top: 7px; transform: rotate(45deg); }
+.hamburger[aria-expanded="true"] .menu-icon span:nth-child(2) { opacity: 0; }
+.hamburger[aria-expanded="true"] .menu-icon span:nth-child(3) { top: 7px; transform: rotate(-45deg); }
+
 @media (max-width: 700px) {
   .site-header { 
     display: flex;
     justify-content: flex-end;
     gap: 8px;
+    padding:
+      calc(10px + env(safe-area-inset-top, 0px))
+      calc(10px + env(safe-area-inset-right, 0px))
+      10px
+      calc(10px + env(safe-area-inset-left, 0px));
   }
   
   .site-header .hamburger { 
@@ -1474,15 +1505,20 @@ a:hover {
   
   .navbar { 
     position: fixed;
-    top: calc(60px + env(safe-area-inset-top));
-    left: 0;
-    right: 0;
+    top: calc(64px + env(safe-area-inset-top, 0px));
+    left: max(0px, env(safe-area-inset-left, 0px));
+    right: max(0px, env(safe-area-inset-right, 0px));
     background: rgba(24, 26, 27, 0.98);
     border-bottom: 1px solid #282a2e;
-    max-height: calc(100dvh - 60px - env(safe-area-inset-top));
+    max-height: calc(100vh - 64px - env(safe-area-inset-top, 0px));
+    max-height: calc(100dvh - 64px - env(safe-area-inset-top, 0px));
     overflow-y: auto;
     display: none;
     z-index: 99;
+  }
+
+  body.mobile-nav-open {
+    overflow: hidden;
   }
   
   .navbar.open { 

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -214,11 +214,34 @@ document.addEventListener('DOMContentLoaded', () => {
   try {
     const navToggle = document.getElementById('navToggle');
     const navbar = document.querySelector('.navbar');
-    if (navToggle && navbar) {
-      navToggle.addEventListener('click', () => {
-        const open = navbar.classList.toggle('open');
+    if (navToggle && navbar && navToggle.dataset.bound !== 'true') {
+      navToggle.dataset.bound = 'true';
+
+      const setOpen = open => {
+        navbar.classList.toggle('open', open);
+        document.body.classList.toggle('mobile-nav-open', open);
         navToggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+        navToggle.setAttribute('aria-label', open ? 'Close menu' : 'Open menu');
+      };
+
+      navToggle.addEventListener('click', () => {
+        setOpen(navToggle.getAttribute('aria-expanded') !== 'true');
       });
+
+      navbar.addEventListener('click', event => {
+        if (event.target.closest('.navbar-link')) setOpen(false);
+      });
+
+      document.addEventListener('keydown', event => {
+        if (event.key === 'Escape') setOpen(false);
+      });
+
+      const mobileMedia = window.matchMedia('(max-width: 700px)');
+      const closeOnDesktop = event => {
+        if (!event.matches) setOpen(false);
+      };
+      if (mobileMedia.addEventListener) mobileMedia.addEventListener('change', closeOnDesktop);
+      else if (mobileMedia.addListener) mobileMedia.addListener(closeOnDesktop);
     }
   } catch (_) {}
 
@@ -395,34 +418,57 @@ document.addEventListener('DOMContentLoaded', () => {
 
 // Consent banner for Plausible analytics (opt-in)
 (function() {
-  try {
-    const el = document.getElementById('consent');
-    if (!el) return;
-    const key = 'consent-analytics';
-    const prior = localStorage.getItem(key);
-    if (prior) {
-      if (prior === 'yes' && typeof window.plausible === 'function') window.plausible('pageview');
-      return; // do not show banner again
+  const el = document.getElementById('consent');
+  if (!el || el.dataset.stableConsent === 'ready') return;
+
+  el.dataset.stableConsent = 'ready';
+  const key = 'consent-analytics';
+
+  const readPreference = () => {
+    try {
+      return window.localStorage.getItem(key);
+    } catch (_) {
+      return null;
     }
-    // show banner
-    el.hidden = false;
+  };
 
-    const setConsent = (value) => {
-      localStorage.setItem(key, value);
-      el.remove();
-      if (value === 'yes' && typeof window.plausible === 'function') window.plausible('pageview');
-    };
+  const savePreference = value => {
+    try {
+      window.localStorage.setItem(key, value);
+    } catch (_) {
+      // Dismissal must still work in Safari private mode or strict privacy settings.
+    }
+  };
 
-    const handleConsentEvent = (event) => {
-      const target = event.target && event.target.closest ? event.target.closest('#consent-accept, #consent-decline') : null;
-      if (!target) return;
-      event.preventDefault();
-      setConsent(target.id === 'consent-accept' ? 'yes' : 'no');
-    };
+  const dismiss = value => {
+    el.hidden = true;
+    el.setAttribute('aria-hidden', 'true');
+    savePreference(value);
+    if (value === 'yes' && typeof window.plausible === 'function') {
+      try {
+        window.plausible('pageview');
+      } catch (_) {}
+    }
+    el.remove();
+  };
 
-    document.addEventListener('click', handleConsentEvent, { passive: false });
-    document.addEventListener('pointerup', handleConsentEvent, { passive: false });
-  } catch (_) {}
+  const prior = readPreference();
+  if (prior === 'yes' || prior === 'no') {
+    dismiss(prior);
+    return;
+  }
+
+  el.hidden = false;
+  el.setAttribute('aria-hidden', 'false');
+
+  document.addEventListener('click', event => {
+    const target = event.target && event.target.closest
+      ? event.target.closest('#consent-accept, #consent-decline')
+      : null;
+    if (!target) return;
+    event.preventDefault();
+    dismiss(target.id === 'consent-accept' ? 'yes' : 'no');
+  }, { capture: true, passive: false });
 })();
 
 // Fetch concise highlights from GitHub profile README

--- a/assets/js/site-ux.js
+++ b/assets/js/site-ux.js
@@ -1,202 +1,386 @@
-(function () {
-  'use strict';
+const SCROLL_TOP_LABELS = {
+  en: 'Scroll to top',
+  es: 'Volver arriba',
+  ca: 'Tornar a dalt'
+};
 
-  var CONSENT_KEY = 'consent-analytics';
-  var MOBILE_QUERY = '(max-width: 1024px)';
-
-  function safeStorageGet(key) {
-    try {
-      return window.localStorage.getItem(key);
-    } catch (error) {
-      return null;
-    }
+const RECRUITER_FALLBACKS = {
+  en: {
+    hero_eyebrow: 'Junior SOC Analyst / Blue Team candidate · Balearic Islands, Spain',
+    hero_statement:
+      'I am looking for an entry-level SOC, Blue Team or security operations role where I can triage alerts, document findings and learn from senior analysts. My public proof of work includes CyberDailyLog, a Raspberry Pi defensive homelab, Linux/Docker practice and documented labs.',
+    projects_intro:
+      'Start here for interview evidence. These case studies explain what was built, why it matters defensively and where public source or lab notes are available.',
+    hero_github: 'GitHub evidence',
+    hero_cv: 'Open CV',
+    hero_tryhackme: 'TryHackMe / HTB lab notes',
+    hero_contact: 'Email Jaime',
+    hero_actions_label: 'Primary portfolio shortcuts',
+    hero_proof_links_label: 'External proof links',
+    proof_strip_label: 'Recruiter snapshot',
+    proof_role_label: 'Target role',
+    proof_role_value: 'Junior SOC / Blue Team',
+    proof_location_label: 'Location',
+    proof_location_value: 'Balearic Islands, Spain · open to remote and hybrid roles',
+    proof_evidence_label: 'Public evidence',
+    proof_evidence_value: 'CyberDailyLog, lab notes and GitHub projects',
+    proof_learning_label: 'Current learning',
+    proof_learning_value: 'Preparing for AWS Cloud Practitioner',
+    project_case_studies: 'Featured proof of work',
+    case_cyber_title: 'CyberDailyLog — daily defensive intelligence pipeline',
+    case_cyber_purpose:
+      'Purpose: practise source-backed security monitoring and prioritisation from public advisories and vulnerability data.',
+    case_cyber_built:
+      'Built: automated collection, validation and a compact portfolio feed with a bundled fallback snapshot.',
+    case_cyber_relevance:
+      'Defensive relevance: demonstrates triage thinking, repeatable reporting, safe rendering of untrusted feed text and GitHub-auditable output.',
+    case_cyber_status: 'Current status: active portfolio project; not a production SOC feed.',
+    case_homelab_title: 'Raspberry Pi defensive homelab',
+    case_homelab_purpose:
+      'Purpose: learn practical Linux administration, networking, monitoring and recovery on a small always-on lab.',
+    case_homelab_built:
+      'Built: Docker service practice, hardening routines, log review, backup checks and network-visibility exercises.',
+    case_homelab_relevance:
+      'Defensive relevance: supports conversations about least privilege, service exposure, resilience and troubleshooting.',
+    case_homelab_status:
+      'Current status: active hands-on learning; the detailed homelab repository is private while public documentation is being prepared.',
+    homelab_public_link: 'View public GitHub work'
+  },
+  es: {
+    hero_eyebrow: 'Candidato a Analista SOC Junior / Blue Team · Islas Baleares, España',
+    hero_statement:
+      'Busco un puesto inicial de SOC, Blue Team u operaciones de seguridad donde pueda analizar y priorizar alertas, documentar hallazgos y aprender de analistas con experiencia. Mi evidencia pública incluye CyberDailyLog, un homelab defensivo con Raspberry Pi, práctica con Linux/Docker y laboratorios documentados.',
+    projects_intro:
+      'Empieza aquí para ver evidencia útil en una entrevista. Estos casos explican qué se construyó, por qué es relevante para la defensa y dónde hay código o notas públicas disponibles.',
+    hero_github: 'Evidencia en GitHub',
+    hero_cv: 'Abrir CV',
+    hero_tryhackme: 'Notas de labs TryHackMe / HTB',
+    hero_contact: 'Escribir a Jaime',
+    hero_actions_label: 'Accesos principales del portfolio',
+    hero_proof_links_label: 'Enlaces a evidencias externas',
+    proof_strip_label: 'Resumen para recruiters',
+    proof_role_label: 'Rol objetivo',
+    proof_role_value: 'SOC Junior / Blue Team',
+    proof_location_label: 'Ubicación',
+    proof_location_value: 'Islas Baleares, España · abierto a puestos remotos e híbridos',
+    proof_evidence_label: 'Evidencia pública',
+    proof_evidence_value: 'CyberDailyLog, notas de laboratorios y proyectos en GitHub',
+    proof_learning_label: 'Aprendizaje actual',
+    proof_learning_value: 'Preparación para AWS Cloud Practitioner',
+    project_case_studies: 'Evidencia práctica destacada',
+    case_cyber_title: 'CyberDailyLog — pipeline diario de inteligencia defensiva',
+    case_cyber_purpose:
+      'Propósito: practicar monitorización y priorización de seguridad basadas en fuentes públicas, avisos y datos de vulnerabilidades.',
+    case_cyber_built:
+      'Construido: recopilación automatizada, validación y un resumen compacto para el portfolio con snapshot local de respaldo.',
+    case_cyber_relevance:
+      'Relevancia defensiva: demuestra criterio de triaje, informes repetibles, renderizado seguro de texto externo y resultados auditables en GitHub.',
+    case_cyber_status: 'Estado actual: proyecto activo de portfolio; no es un feed SOC de producción.',
+    case_homelab_title: 'Homelab defensivo con Raspberry Pi',
+    case_homelab_purpose:
+      'Propósito: aprender administración Linux, redes, monitorización y recuperación en un pequeño laboratorio siempre activo.',
+    case_homelab_built:
+      'Construido: práctica con servicios Docker, rutinas de hardening, revisión de logs, comprobaciones de backup y ejercicios de visibilidad de red.',
+    case_homelab_relevance:
+      'Relevancia defensiva: permite hablar del principio de mínimo privilegio, exposición de servicios, resiliencia y resolución de problemas.',
+    case_homelab_status:
+      'Estado actual: aprendizaje práctico activo; el repositorio detallado del homelab es privado mientras preparo documentación pública.',
+    homelab_public_link: 'Ver trabajo público en GitHub'
+  },
+  ca: {
+    hero_eyebrow: 'Candidat a Analista SOC Junior / Blue Team · Illes Balears, Espanya',
+    hero_statement:
+      'Busco una posició inicial de SOC, Blue Team o operacions de seguretat on pugui analitzar i prioritzar alertes, documentar conclusions i aprendre d’analistes amb experiència. La meva evidència pública inclou CyberDailyLog, un homelab defensiu amb Raspberry Pi, pràctica amb Linux/Docker i laboratoris documentats.',
+    projects_intro:
+      'Comença aquí per veure evidència útil en una entrevista. Aquests casos expliquen què s’ha construït, per què és rellevant per a la defensa i on hi ha codi o notes públiques disponibles.',
+    hero_github: 'Evidència a GitHub',
+    hero_cv: 'Obrir CV',
+    hero_tryhackme: 'Notes de labs TryHackMe / HTB',
+    hero_contact: 'Escriure a Jaime',
+    hero_actions_label: 'Accessos principals del portfolio',
+    hero_proof_links_label: 'Enllaços a evidències externes',
+    proof_strip_label: 'Resum per a recruiters',
+    proof_role_label: 'Rol objectiu',
+    proof_role_value: 'SOC Junior / Blue Team',
+    proof_location_label: 'Ubicació',
+    proof_location_value: 'Illes Balears, Espanya · obert a llocs remots i híbrids',
+    proof_evidence_label: 'Evidència pública',
+    proof_evidence_value: 'CyberDailyLog, notes de laboratoris i projectes a GitHub',
+    proof_learning_label: 'Aprenentatge actual',
+    proof_learning_value: 'Preparació per a AWS Cloud Practitioner',
+    project_case_studies: 'Evidència pràctica destacada',
+    case_cyber_title: 'CyberDailyLog — pipeline diari d’intel·ligència defensiva',
+    case_cyber_purpose:
+      'Propòsit: practicar el monitoratge i la priorització de seguretat basats en fonts públiques, avisos i dades de vulnerabilitats.',
+    case_cyber_built:
+      'Construït: recopilació automatitzada, validació i un resum compacte per al portfolio amb snapshot local de suport.',
+    case_cyber_relevance:
+      'Rellevància defensiva: demostra criteri de triatge, informes repetibles, renderitzat segur de text extern i resultats auditables a GitHub.',
+    case_cyber_status: 'Estat actual: projecte actiu de portfolio; no és un feed SOC de producció.',
+    case_homelab_title: 'Homelab defensiu amb Raspberry Pi',
+    case_homelab_purpose:
+      'Propòsit: aprendre administració Linux, xarxes, monitoratge i recuperació en un petit laboratori sempre actiu.',
+    case_homelab_built:
+      'Construït: pràctica amb serveis Docker, rutines de hardening, revisió de logs, comprovacions de backup i exercicis de visibilitat de xarxa.',
+    case_homelab_relevance:
+      'Rellevància defensiva: permet parlar del principi de mínim privilegi, exposició de serveis, resiliència i resolució de problemes.',
+    case_homelab_status:
+      'Estat actual: aprenentatge pràctic actiu; el repositori detallat del homelab és privat mentre preparo documentació pública.',
+    homelab_public_link: 'Veure treball públic a GitHub'
   }
+};
 
-  function safeStorageSet(key, value) {
-    try {
-      window.localStorage.setItem(key, value);
-    } catch (error) {
-      // Safari private browsing and strict privacy modes may block storage.
-      // The interaction must still complete for the current page.
-    }
-  }
+const COMPACT_AT = 360;
+const EXPAND_BELOW = 180;
+const SHOW_SCROLL_TOP_AT = 500;
+const DESKTOP_QUERY = '(min-width: 1025px)';
 
-  function installCompatibilityStyles() {
-    if (document.getElementById('ios-ui-stability-styles')) return;
+function currentLanguage() {
+  const language = (document.documentElement.lang || 'en').toLowerCase();
+  return Object.hasOwn(SCROLL_TOP_LABELS, language) ? language : 'en';
+}
 
-    var style = document.createElement('style');
-    style.id = 'ios-ui-stability-styles';
-    style.textContent = [
-      '.hamburger{touch-action:manipulation;-webkit-tap-highlight-color:transparent;}',
-      '.hamburger .menu-icon{display:block;width:22px;height:16px;position:relative;}',
-      '.hamburger .menu-icon span{position:absolute;left:0;width:100%;height:2px;border-radius:2px;background:currentColor;transition:transform .2s ease,opacity .2s ease,top .2s ease;}',
-      '.hamburger .menu-icon span:nth-child(1){top:0;}',
-      '.hamburger .menu-icon span:nth-child(2){top:7px;}',
-      '.hamburger .menu-icon span:nth-child(3){top:14px;}',
-      '.hamburger[aria-expanded="true"] .menu-icon span:nth-child(1){top:7px;transform:rotate(45deg);}',
-      '.hamburger[aria-expanded="true"] .menu-icon span:nth-child(2){opacity:0;}',
-      '.hamburger[aria-expanded="true"] .menu-icon span:nth-child(3){top:7px;transform:rotate(-45deg);}',
-      '@media(max-width:1024px){',
-      '.site-header{position:fixed;top:0;right:0;z-index:10020;pointer-events:none;padding:calc(10px + env(safe-area-inset-top,0px)) calc(10px + env(safe-area-inset-right,0px)) 0 0;}',
-      '.hamburger{pointer-events:auto;display:flex!important;align-items:center;justify-content:center;width:46px;height:46px;min-width:46px;min-height:46px;padding:0!important;border-radius:12px;font-size:0!important;line-height:1;background:rgba(18,18,18,.96);}',
-      '.navbar{display:none!important;}',
-      '.navbar.open{display:block!important;position:fixed;inset:calc(66px + env(safe-area-inset-top,0px)) 10px auto 10px;z-index:10010;max-height:calc(100dvh - 86px - env(safe-area-inset-top,0px));max-height:calc(100vh - 86px - env(safe-area-inset-top,0px));overflow-y:auto;-webkit-overflow-scrolling:touch;border-radius:14px;background:rgba(18,18,18,.98);box-shadow:0 18px 50px rgba(0,0,0,.45);}',
-      '.navbar.open .navbar-list{display:flex!important;flex-direction:column!important;max-height:none!important;overflow:visible!important;padding:10px!important;}',
-      '.navbar.open .navbar-link{min-height:44px;}',
-      'body.mobile-nav-open{overflow:hidden;}',
-      '}',
-      '@media(min-width:1025px){',
-      '.contacts-list{flex:0 0 auto;max-height:none!important;overflow:visible!important;}',
-      '.contact-item{width:100%;min-width:0;align-items:flex-start;}',
-      '.contact-info{flex:1 1 auto;min-width:0;}',
-      '.contact-info .contact-link,.contact-info address{display:block;width:100%;max-width:100%;white-space:normal;overflow-wrap:anywhere;word-break:break-word;}',
-      '}',
-      '@media(min-width:1025px) and (max-height:620px){.avatar-bg{display:none!important;}}'
-    ].join('');
-    document.head.appendChild(style);
-  }
+function installRecruiterFallbacks() {
+  window.translations = window.translations || {};
+  Object.entries(RECRUITER_FALLBACKS).forEach(([language, copy]) => {
+    window.translations[language] = { ...copy, ...(window.translations[language] || {}) };
+  });
+}
 
-  function initializeConsent() {
-    var banner = document.getElementById('consent');
-    if (!banner || banner.getAttribute('data-stable-consent') === 'ready') return;
+installRecruiterFallbacks();
 
-    banner.setAttribute('data-stable-consent', 'ready');
-    var prior = safeStorageGet(CONSENT_KEY);
+function setInteractiveState(container, hidden) {
+  if (!container) return;
 
-    function dismiss(value) {
-      banner.hidden = true;
-      banner.setAttribute('aria-hidden', 'true');
-      banner.style.display = 'none';
-      document.documentElement.style.setProperty('--scroll-top-consent-offset', '0px');
-      safeStorageSet(CONSENT_KEY, value);
+  container.setAttribute('aria-hidden', hidden ? 'true' : 'false');
+  if ('inert' in container) container.inert = hidden;
 
-      if (value === 'yes' && typeof window.plausible === 'function') {
-        try { window.plausible('pageview'); } catch (error) {}
+  container.querySelectorAll('a, button, input, select, textarea, [tabindex]').forEach(element => {
+    if (hidden) {
+      if (!element.hasAttribute('data-ux-original-tabindex')) {
+        element.setAttribute(
+          'data-ux-original-tabindex',
+          element.hasAttribute('tabindex') ? element.getAttribute('tabindex') : '__none__'
+        );
       }
-
-      if (banner.parentNode) banner.parentNode.removeChild(banner);
-    }
-
-    if (prior === 'yes' || prior === 'no') {
-      dismiss(prior);
+      element.setAttribute('tabindex', '-1');
       return;
     }
 
-    banner.hidden = false;
-    banner.removeAttribute('aria-hidden');
-    banner.style.display = '';
+    const original = element.getAttribute('data-ux-original-tabindex');
+    if (original === '__none__') element.removeAttribute('tabindex');
+    else if (original !== null) element.setAttribute('tabindex', original);
+    element.removeAttribute('data-ux-original-tabindex');
+  });
+}
 
-    var accept = document.getElementById('consent-accept');
-    var decline = document.getElementById('consent-decline');
+function initializeSiteUx() {
+  if (document.documentElement.dataset.siteUx === 'ready') return;
+  document.documentElement.dataset.siteUx = 'ready';
 
-    function bind(button, value) {
-      if (!button) return;
-      var cleanButton = button.cloneNode(true);
-      button.parentNode.replaceChild(cleanButton, button);
+  const body = document.body;
+  const desktopMedia = window.matchMedia(DESKTOP_QUERY);
+  const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+  const scrollingElement = () => document.scrollingElement || document.documentElement;
 
-      var handled = false;
-      function activate(event) {
-        if (handled) return;
-        handled = true;
-        if (event) {
-          event.preventDefault();
-          event.stopPropagation();
-        }
-        dismiss(value);
+  const originalNavList = document.querySelector('.navbar-list');
+  const navList = originalNavList ? originalNavList.cloneNode(true) : null;
+  if (originalNavList && navList) originalNavList.replaceWith(navList);
+
+  const navLinks = navList ? Array.from(navList.querySelectorAll('.navbar-link[href^="#"]')) : [];
+  const sections = navLinks
+    .map(link => document.getElementById(link.getAttribute('href')?.slice(1) || ''))
+    .filter(Boolean);
+
+  const originalScrollButton = document.getElementById('scrollTop');
+  const scrollButton = originalScrollButton ? originalScrollButton.cloneNode(false) : null;
+
+  if (originalScrollButton && scrollButton) {
+    originalScrollButton.replaceWith(scrollButton);
+    scrollButton.type = 'button';
+    scrollButton.innerHTML = `
+      <svg class="scroll-btn-icon" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+        <path d="M6 14.5 12 8l6 6.5"></path>
+        <path d="M12 8v10"></path>
+      </svg>
+    `;
+  }
+
+  const avatar = document.querySelector('.avatar-bg');
+  const contacts = document.querySelector('.contacts-list');
+  const separators = Array.from(document.querySelectorAll('.sidebar-info > .separator'));
+  const consent = document.getElementById('consent');
+  const homelabEvidenceLink = document.querySelector('.case-study-card:nth-child(2) .inline-evidence-link');
+  if (homelabEvidenceLink) homelabEvidenceLink.setAttribute('data-txt', 'homelab_public_link');
+
+  let condensed = false;
+  let animationFrame = 0;
+  let activeSectionId = '';
+
+  function recruiterCopy() {
+    const language = currentLanguage();
+    return { ...RECRUITER_FALLBACKS[language], ...(window.translations?.[language] || {}) };
+  }
+
+  function updateRecruiterTranslations() {
+    const copy = recruiterCopy();
+    document.querySelectorAll('[data-txt]').forEach(element => {
+      const key = element.getAttribute('data-txt');
+      if (key && Object.hasOwn(RECRUITER_FALLBACKS[currentLanguage()], key)) {
+        element.textContent = copy[key];
       }
+    });
 
-      cleanButton.addEventListener('click', activate, false);
-      cleanButton.addEventListener('touchend', activate, false);
-    }
-
-    bind(accept, 'yes');
-    bind(decline, 'no');
+    document.querySelector('.hero-actions')?.setAttribute('aria-label', copy.hero_actions_label);
+    document.querySelector('.hero-proof-links')?.setAttribute('aria-label', copy.hero_proof_links_label);
+    document.querySelector('.proof-strip')?.setAttribute('aria-label', copy.proof_strip_label);
   }
 
-  function initializeMobileNavigation() {
-    var oldToggle = document.getElementById('navToggle');
-    var navbar = document.querySelector('.navbar');
-    if (!oldToggle || !navbar) return;
+  function updateScrollButtonLabel() {
+    if (!scrollButton) return;
+    const label = SCROLL_TOP_LABELS[currentLanguage()];
+    scrollButton.setAttribute('aria-label', label);
+    scrollButton.setAttribute('title', label);
+  }
 
-    var toggle = oldToggle.cloneNode(false);
-    toggle.id = 'navToggle';
-    toggle.className = oldToggle.className;
-    toggle.type = 'button';
-    toggle.setAttribute('aria-controls', 'navList');
-    toggle.setAttribute('aria-expanded', 'false');
-    toggle.setAttribute('aria-label', 'Open menu');
-    toggle.innerHTML = '<span class="menu-icon" aria-hidden="true"><span></span><span></span><span></span></span>';
-    oldToggle.parentNode.replaceChild(toggle, oldToggle);
-
-    function setOpen(open) {
-      navbar.classList.toggle('open', open);
-      document.body.classList.toggle('mobile-nav-open', open);
-      toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
-      toggle.setAttribute('aria-label', open ? 'Close menu' : 'Open menu');
-    }
-
-    function toggleMenu(event) {
-      if (event) {
-        event.preventDefault();
-        event.stopPropagation();
+  function updateConsentOffset() {
+    let offset = 0;
+    if (consent && consent.isConnected && !consent.hidden) {
+      const style = window.getComputedStyle(consent);
+      const rect = consent.getBoundingClientRect();
+      if (style.display !== 'none' && style.visibility !== 'hidden' && rect.height > 0) {
+        offset = Math.max(0, window.innerHeight - rect.top + 12);
       }
-      setOpen(toggle.getAttribute('aria-expanded') !== 'true');
+    }
+    document.documentElement.style.setProperty('--scroll-top-consent-offset', `${Math.ceil(offset)}px`);
+  }
+
+  function setCondensed(nextCondensed) {
+    const next = desktopMedia.matches && nextCondensed;
+    if (next === condensed && contacts?.getAttribute('aria-hidden') !== null) return;
+
+    condensed = next;
+    body.classList.toggle('sidebar-condensed', condensed);
+    setInteractiveState(contacts, condensed);
+    if (avatar) avatar.setAttribute('aria-hidden', condensed ? 'true' : 'false');
+    separators.forEach(separator => separator.setAttribute('aria-hidden', condensed ? 'true' : 'false'));
+  }
+
+  function setScrollButtonVisible(visible) {
+    if (!scrollButton) return;
+    scrollButton.classList.toggle('visible', visible);
+    scrollButton.setAttribute('aria-hidden', visible ? 'false' : 'true');
+    scrollButton.setAttribute('tabindex', visible ? '0' : '-1');
+  }
+
+  function keepActiveLinkVisible(link) {
+    if (!navList || !link || !desktopMedia.matches) return;
+    const navRect = navList.getBoundingClientRect();
+    const linkRect = link.getBoundingClientRect();
+    if (linkRect.top < navRect.top || linkRect.bottom > navRect.bottom) {
+      link.scrollIntoView({ block: 'nearest', inline: 'nearest', behavior: 'auto' });
+    }
+  }
+
+  function setActiveSection(sectionId) {
+    if (!sectionId || sectionId === activeSectionId) return;
+    activeSectionId = sectionId;
+
+    navLinks.forEach(link => {
+      const active = link.getAttribute('href') === `#${sectionId}`;
+      link.classList.toggle('active', active);
+      if (active) link.setAttribute('aria-current', 'location');
+      else link.removeAttribute('aria-current');
+    });
+
+    keepActiveLinkVisible(navLinks.find(link => link.getAttribute('href') === `#${sectionId}`));
+  }
+
+  function updateActiveSection() {
+    if (!sections.length) return;
+
+    const scroller = scrollingElement();
+    const atDocumentEnd = scroller.scrollTop + window.innerHeight >= scroller.scrollHeight - 4;
+    if (atDocumentEnd) {
+      setActiveSection(sections.at(-1).id);
+      return;
     }
 
-    toggle.addEventListener('click', toggleMenu, false);
-    toggle.addEventListener('touchend', function (event) {
-      event.preventDefault();
-      toggleMenu(event);
-    }, false);
-
-    navbar.addEventListener('click', function (event) {
-      var target = event.target;
-      while (target && target !== navbar && target.tagName !== 'A') target = target.parentNode;
-      if (target && target.tagName === 'A') setOpen(false);
-    }, false);
-
-    document.addEventListener('keydown', function (event) {
-      if (event.key === 'Escape') setOpen(false);
-    }, false);
-
-    window.addEventListener('resize', function () {
-      if (!window.matchMedia(MOBILE_QUERY).matches) setOpen(false);
-    }, false);
+    const readingLine = Math.min(window.innerHeight * 0.38, 320);
+    const crossed = sections.filter(section => section.getBoundingClientRect().top <= readingLine);
+    const candidate = crossed.at(-1) || sections[0];
+    setActiveSection(candidate.id);
   }
 
-  function initializeScrollButton() {
-    var button = document.getElementById('scrollTop');
-    if (!button) return;
+  function updateScrollState() {
+    animationFrame = 0;
+    const scrollTop = scrollingElement().scrollTop;
 
-    function update() {
-      var top = window.pageYOffset || document.documentElement.scrollTop || 0;
-      button.classList.toggle('visible', top >= 500);
-    }
+    if (!desktopMedia.matches) setCondensed(false);
+    else if (!condensed && scrollTop >= COMPACT_AT) setCondensed(true);
+    else if (condensed && scrollTop <= EXPAND_BELOW) setCondensed(false);
 
-    button.addEventListener('click', function () {
-      try {
-        window.scrollTo({ top: 0, behavior: 'smooth' });
-      } catch (error) {
-        window.scrollTo(0, 0);
-      }
-    }, false);
-
-    window.addEventListener('scroll', update, { passive: true });
-    update();
+    setScrollButtonVisible(scrollTop >= SHOW_SCROLL_TOP_AT);
+    updateConsentOffset();
+    updateActiveSection();
   }
 
-  function initialize() {
-    if (document.documentElement.getAttribute('data-site-ux') === 'ready') return;
-    document.documentElement.setAttribute('data-site-ux', 'ready');
-    installCompatibilityStyles();
-    initializeConsent();
-    initializeMobileNavigation();
-    initializeScrollButton();
+  function requestScrollStateUpdate() {
+    if (!animationFrame) animationFrame = window.requestAnimationFrame(updateScrollState);
   }
 
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', initialize, false);
-  } else {
-    initialize();
+  navLinks.forEach(link => {
+    link.addEventListener('click', () => {
+      const sectionId = link.getAttribute('href')?.slice(1);
+      if (sectionId) setActiveSection(sectionId);
+    });
+  });
+
+  if (scrollButton) {
+    scrollButton.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: reduceMotion.matches ? 'auto' : 'smooth' });
+    });
   }
-}());
+
+  new window.MutationObserver(() => {
+    updateScrollButtonLabel();
+    updateRecruiterTranslations();
+  }).observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['lang']
+  });
+
+  if (consent) {
+    new window.MutationObserver(updateConsentOffset).observe(consent, {
+      attributes: true,
+      attributeFilter: ['hidden', 'style', 'class']
+    });
+    if ('ResizeObserver' in window) new window.ResizeObserver(updateConsentOffset).observe(consent);
+  }
+
+  if ('IntersectionObserver' in window) {
+    const observer = new window.IntersectionObserver(requestScrollStateUpdate, {
+      root: null,
+      rootMargin: '0px',
+      threshold: [0, 0.01, 0.1, 0.25, 0.5]
+    });
+    sections.forEach(section => observer.observe(section));
+  }
+
+  window.addEventListener('scroll', requestScrollStateUpdate, { passive: true });
+  window.addEventListener('resize', requestScrollStateUpdate, { passive: true });
+  desktopMedia.addEventListener('change', requestScrollStateUpdate);
+  reduceMotion.addEventListener('change', requestScrollStateUpdate);
+
+  updateRecruiterTranslations();
+  updateScrollButtonLabel();
+  setInteractiveState(contacts, false);
+  setScrollButtonVisible(false);
+  updateScrollState();
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initializeSiteUx, { once: true });
+} else {
+  initializeSiteUx();
+}

--- a/index.html
+++ b/index.html
@@ -71,7 +71,9 @@
 <a class="skip-link" href="#maincontent">Skip to main content</a>
 
 <header class="site-header" role="banner">
-  <button id="navToggle" class="hamburger" aria-controls="navList" aria-expanded="false" aria-label="Menu">Menu</button>
+  <button id="navToggle" class="hamburger" aria-controls="navList" aria-expanded="false" aria-label="Open menu" type="button">
+    <span class="menu-icon" aria-hidden="true"><span></span><span></span><span></span></span>
+  </button>
 </header>
 
 <div class="bg-animation"></div>


### PR DESCRIPTION
## What changed

- restore the recruiter snapshot fallbacks, translated labels, scrollspy, scroll-to-top control and progressive sidebar behavior removed by the previous mobile-navigation change
- make the mobile menu a single-owner interaction with correct `aria-expanded` and open/close labels
- move the menu icon styling into the static stylesheet so it complies with the site's CSP
- make consent dismissal reliable when localStorage is unavailable, including Safari private/strict privacy modes
- add safe-area and dynamic viewport handling for iPhone-sized screens

## Why

The latest portfolio integration caused the QA workflow to fail 27 tests. The replacement `site-ux.js` removed recruiter-facing behavior, while duplicate navigation handlers toggled the menu twice and runtime-injected CSS violated the site's CSP.

## Impact

This restores the portfolio's recruiter-facing content and keeps navigation, consent, accessibility and responsive behavior stable without changing certificate data, public links or deployment settings.

## Validation

- `npm run lint`
- `VITE_BUILD_VERSION=automation-audit npm run build`
- `npm run validate:local`
- `npm run test:validator-refs`
- `npm run test:e2e:ci` — 43/43 Chromium tests passed

Deployment configuration is intentionally out of scope: GitHub Pages still needs a separate human decision about branch publishing versus GitHub Actions publishing.