### PR TITLE
Stop mutating GitHub Pages settings in CI

### DIFF
--- a/.github/workflows/site-qa-pages.yml
+++ b/.github/workflows/site-qa-pages.yml
@@ -124,19 +124,8 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+    # Repository prerequisite: Settings > Pages > Source must be set to GitHub Actions.
     steps:
-      - name: Select workflow-based Pages publishing
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          curl --fail-with-body --silent --show-error \
-            --request PUT \
-            --header "Accept: application/vnd.github+json" \
-            --header "Authorization: Bearer ${GH_TOKEN}" \
-            --header "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/pages" \
-            --data '{"build_type":"workflow"}'
       - name: Deploy tested Pages artifact
         id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4 verified release


### PR DESCRIPTION
## What changed

- removes the runtime API call that tries to change the repository's GitHub Pages publishing mode
- keeps the tested artifact deployment through `actions/deploy-pages`
- documents the required repository setting next to the deploy job

## Why

The workflow's QA and artifact upload succeed, but the deploy job currently fails with HTTP 403 because the workflow token cannot mutate repository Pages settings. Publishing mode is a repository-level administrative decision and should not be changed on every deployment.

## Validation

- workflow YAML parsed successfully
- the pull-request QA run must pass before review
- deploy remains skipped on pull requests by design

## Manual prerequisite before merge

In **Settings → Pages → Build and deployment → Source**, select **GitHub Actions** and save. Then merge this PR. The next push to `main` will deploy the exact artifact that passed QA.

Do not merge this PR before changing that setting, otherwise `actions/deploy-pages` cannot publish while the repository remains in branch-based Pages mode.