### PR TITLE
Shrink the Pages artifact by excluding unused PDFs

### DIFF
--- a/scripts/validate-local.mjs
+++ b/scripts/validate-local.mjs
@@ -15,7 +15,7 @@ const read = p => readFile(p, 'utf8');
 const readJson = async p => JSON.parse(await read(p));
 const stable = value => JSON.stringify(value);
 
-for (const f of ['index.html','assets/locales/en.json','assets/locales/es.json','assets/locales/ca.json','certificates.json','software.json','tools.json','assets/Jamie Ramsden CV.pdf']) await mustExist(join(root, f));
+for (const f of ['index.html','assets/locales/en.json','assets/locales/es.json','assets/locales/ca.json','certificates.json','software.json','tools.json','assets/pdfs/Jaime Ramsden de Frutos CV.pdf']) await mustExist(join(root, f));
 for (const f of ['index.html','certificates.json','software.json','tools.json','assets/locales/en.json','assets/locales/es.json','assets/locales/ca.json']) await mustExist(join(distDir, f));
 
 let html = '';
@@ -47,6 +47,11 @@ const privateNames = ['MyLinkedinInfo','SearchQueries.csv','ImportedContacts.csv
 const generatedPaths = existsSync(distDir) ? readdirSync(distDir, { recursive: true, withFileTypes: true })
   .filter(d => d.isFile() || d.isDirectory())
   .map(d => path.relative(distDir, path.join(d.parentPath || d.path, d.name)).replaceAll('\\', '/')) : [];
+const generatedPdfs = generatedPaths.filter(generated => /\.pdf$/i.test(generated)).sort();
+const expectedGeneratedPdfs = ['assets/pdfs/Jaime Ramsden de Frutos CV.pdf'];
+if (stable(generatedPdfs) !== stable(expectedGeneratedPdfs)) {
+  fail(`Generated PDF allowlist mismatch: expected ${expectedGeneratedPdfs.join(', ')}, found ${generatedPdfs.join(', ') || 'none'}`);
+}
 for (const name of privateNames) {
   const lower = name.toLowerCase();
   if (generatedPaths.some(generated => generated.toLowerCase().includes(lower))) fail(`Private LinkedIn export marker found in generated artifact: ${name}`);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -52,10 +52,8 @@ export default defineConfig({
         { src: 'assets/css', dest: '.' },
         { src: 'assets/js', dest: '.' },
         { src: 'assets/locales', dest: '.' },
-        { src: 'assets/pdfs', dest: '.' },
+        { src: 'assets/pdfs/Jaime Ramsden de Frutos CV.pdf', dest: '.' },
         { src: 'assets/data', dest: '.' },
-        { src: 'assets/Jamie Ramsden CV.pdf', dest: '.' },
-        { src: 'assets/Jamie Ramsden Cover Letter.pdf', dest: '.' },
         { src: 'UpgradeHub', dest: '.' },
         // Copy data JSON files used by runtime fetches
         { src: 'certificates.json', dest: '.' },


### PR DESCRIPTION
## Summary

- copy only the CV linked by the portfolio into the GitHub Pages artifact
- keep every certificate PDF in its source repository, so GitHub blob viewers and evidence links remain unchanged
- enforce an explicit generated-PDF allowlist during validation

## Impact

- generated artifact: **33 MB → 13 MB**
- generated PDFs: **31 → 1**
- avoids publishing duplicate certificate binaries that the site no longer links

## Validation

- `npm test`
- production build and canonical build-version check
- artifact privacy and local-reference validation
- full Chromium suite: 42 passed; one long interaction test hit the 30 s local timeout once
- isolated rerun of that interaction test: passed in 12.6 s

No source certificate, certificate URL, recruiter navigation, or CV URL is removed.