### PR TITLE
Align repository docs with the live portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Run the same source and generated-artifact validation used by CI:
 ```bash
 npm test
 npm run test:validator-refs
-npm run validate:version
+npm run validate:version -- --source-version "$(sed -n 's/^VITE_BUILD_VERSION=//p' .env.production.local)"
 npm run validate:privacy
 npm run test:e2e:ci
 git diff --check

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Sports Science is intentionally kept as education/background only and not used a
 The portfolio is a Vite-built static site with client-side enhancements:
 
 - EN / ES / CA translations via `assets/js/translate.js` and `assets/locales/*.json`;
-- dynamic certificate loading from `certificates.json`, including issuer filters and PDF/image links;
+- dynamic certificate loading from `certificates.json`, including issuer filters and per-certificate evidence links to GitHub viewers or official issuers;
 - dynamic software and tools lists from `software.json` and `tools.json`;
 - dynamic GitHub repository fetching from the public GitHub REST API, cached in `sessionStorage` for one hour;
 - CSP, canonical URL, Open Graph metadata, Twitter metadata and JSON-LD structured data in `index.html`;
@@ -33,14 +33,14 @@ The portfolio is a Vite-built static site with client-side enhancements:
 - `assets/js/translate.js` — built-in translations plus JSON locale loading.
 - `assets/locales/en.json`, `assets/locales/es.json`, `assets/locales/ca.json` — external translation dictionaries.
 - `certificates.json`, `software.json`, `tools.json` — dynamic data sources.
-- `assets/pdfs/` and `assets/Images/` — valid production assets used by the page.
+- `assets/pdfs/` and `assets/Images/` — source evidence and media; the Pages build publishes only explicitly allowlisted assets, including the linked CV.
 
 ## Development
 
 Install dependencies:
 
 ```bash
-npm install
+npm ci
 ```
 
 Run a local development server:
@@ -63,25 +63,22 @@ npm run preview
 
 ## Validation checklist
 
-Useful checks before publishing changes:
+Run the same source and generated-artifact validation used by CI:
 
 ```bash
-npm run build
-node --check assets/js/script.js
-node --check assets/js/translate.js
-python3 - <<'PY'
-from html.parser import HTMLParser
-HTMLParser().feed(open('index.html', encoding='utf-8').read())
-print('index.html parsed')
-PY
+npm test
+npm run test:validator-refs
+npm run validate:version
+npm run validate:privacy
+npm run test:e2e:ci
 git diff --check
 ```
 
-For link and asset checks, parse `index.html` and JSON data sources to verify local `href` and `src` targets exist. For visual checks, use Playwright or another browser tool if installed.
+Install Playwright's Chromium browser once before the end-to-end command with `npx playwright install chromium`.
 
 ## Deployment
 
-The repository contains a placeholder GitHub Actions deployment workflow, but automated GitHub Pages deployment is not currently configured in that workflow. Before changing the deployment model, verify whether GitHub Pages serves the repository root, the `dist/` directory, or another configured source in the repository settings.
+`.github/workflows/site-qa-pages.yml` is the deployment authority. Pull requests build and validate the site without deploying it. A successful push to `main` uploads the exact tested `dist/` artifact to GitHub Pages and then audits the live build version and public resources.
 
 ## License
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,31 +1,24 @@
-# TODO – Site Improvements (ordered by priority)
+# Portfolio roadmap
 
-## High
-- [ ] Add a descriptive `<title>` and `<meta name="description">` (done)
-- [ ] Generate and publish `sitemap.xml` (done)
-- [ ] Optimize all images (convert to WebP, lazy-load, add `srcset`)
-- [ ] Implement a responsive navigation menu (hamburger on mobile)
-- [ ] Add a simple contact form (Netlify Forms / Formspree) with spam protection
+This file tracks only work that remains useful for the production portfolio.
 
-## Medium
-- [ ] Add a lightweight analytics script (Plausible or Umami) with GDPR consent banner
-- [ ] Create a `robots.txt` that allows all crawling (done)
-- [ ] Add Open Graph and Twitter Card meta tags for rich sharing
-- [ ] Add a `CNAME` file (future-proof for a custom domain)
-- [ ] Write a `CHANGELOG.md` entry documenting the site launch
+## Next
 
-## Low
-- [ ] Add JSON-LD structured data for `Person` and `WebSite` (Person added)
-- [ ] Add a “Skip to content” link for screen‑reader users (done)
-- [ ] Add Subresource Integrity hashes to any external scripts/styles
-- [ ] Set up a backup branch (`backup-site`) with the built `_site/` folder
-- [ ] Write a short “Contributing” guide for anyone who wants to help improve the site
+- [ ] Optimize the largest images and add responsive sources without reducing certificate legibility.
+- [ ] Publish a carefully anonymized defensive-homelab case study when the evidence is ready.
+- [ ] Add a scheduled external-link audit for GitHub, Credly and issuer evidence URLs.
 
+## Later
 
-Commit this file after creation:
+- [ ] Remove obsolete, unreferenced front-end files after visual regression coverage confirms they are unnecessary.
+- [ ] Add a custom domain only when a stable professional domain has been selected.
+- [ ] Add a short changelog for recruiter-visible releases.
 
-```
-git add TODO.md
-git commit -m "docs: add TODO list for site improvements"
-git push
-```
+## Completed foundations
+
+- [x] Responsive navigation, keyboard access and skip link.
+- [x] EN / ES / CA translations with resilient locale fallback.
+- [x] Metadata, Open Graph, sitemap, robots.txt and JSON-LD.
+- [x] Per-certificate GitHub or official-issuer evidence links and issuer filters.
+- [x] Consent-aware Plausible analytics.
+- [x] Gated GitHub Pages deployment with Playwright, accessibility, privacy and production audits.


### PR DESCRIPTION
## Summary

- describe certificate evidence links as GitHub viewers or official issuer pages
- replace obsolete manual validation snippets with the actual project commands
- document the tested GitHub Actions → Pages deployment now in production
- replace the stale mixed done/TODO checklist with a concise current roadmap

## Why

The repository front page still claimed Pages automation was a placeholder and listed completed work as unfinished. Accurate public documentation makes the project easier for recruiters and contributors to assess.

## Validation

- `git diff --check`
- verified referenced QA documentation exists
- documentation-only change; the normal full CI workflow remains authoritative