### PR TITLE
Mirror portfolio delivery architecture

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -727,6 +727,90 @@ main section[id] {
   line-height: 1.75;
 }
 
+.delivery-map {
+  margin: 34px 0 0;
+  padding: 0;
+}
+
+.delivery-map figcaption {
+  margin-bottom: 14px;
+  color: var(--orange);
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.delivery-flow {
+  display: grid;
+  border: 1px solid var(--rule);
+  background:
+    linear-gradient(135deg, rgba(247, 147, 26, 0.05), transparent 56%),
+    rgba(8, 10, 13, 0.38);
+}
+
+.delivery-node {
+  position: relative;
+  padding: 18px 20px;
+  border-bottom: 1px solid var(--rule);
+}
+
+.delivery-node + .delivery-node::before {
+  position: absolute;
+  top: -9px;
+  left: 20px;
+  width: 16px;
+  height: 16px;
+  border: 1px solid var(--rule-bright);
+  border-radius: 50%;
+  content: "↓";
+  background: var(--ink-raised);
+  color: var(--orange);
+  font-family: var(--mono);
+  font-size: 9px;
+  line-height: 14px;
+  text-align: center;
+}
+
+.delivery-node > span {
+  display: block;
+  color: var(--orange);
+  font-family: var(--mono);
+  font-size: 8px;
+  letter-spacing: 0.08em;
+}
+
+.delivery-node strong {
+  display: block;
+  margin-top: 7px;
+  color: var(--paper);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.delivery-node.is-artifact {
+  background: rgba(247, 147, 26, 0.045);
+}
+
+.delivery-targets {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+
+.delivery-targets span {
+  padding: 16px 20px;
+  color: var(--paper-dim);
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.05em;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.delivery-targets span + span {
+  border-left: 1px solid var(--rule);
+}
+
 .project-pipeline {
   margin: 38px 0 0;
   padding: 0;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -205,6 +205,13 @@ const content = {
             "Evidence links point to exact certificates",
             "GitHub Pages deployment gated by validation",
           ],
+          delivery: {
+            label: "One source, two identical delivery paths",
+            source: "Portfolio source",
+            checks: "Lint · build · browser QA",
+            artifact: "Validated static artifact",
+            targets: ["GitHub Pages", "Docker / Nginx"],
+          },
           href: links.portfolio,
           secondaryHref: "",
           secondaryLabel: "",
@@ -554,6 +561,13 @@ const content = {
             "Enlaces a certificados concretos",
             "Despliegue en GitHub Pages condicionado a validación",
           ],
+          delivery: {
+            label: "Una fuente, dos rutas de entrega idénticas",
+            source: "Código del portfolio",
+            checks: "Lint · build · QA de navegador",
+            artifact: "Artefacto estático validado",
+            targets: ["GitHub Pages", "Docker / Nginx"],
+          },
           href: links.portfolio,
           secondaryHref: "",
           secondaryLabel: "",
@@ -903,6 +917,13 @@ const content = {
             "Enllaços a certificats concrets",
             "Desplegament a GitHub Pages condicionat a validació",
           ],
+          delivery: {
+            label: "Una font, dues rutes de lliurament idèntiques",
+            source: "Codi del portfolio",
+            checks: "Lint · build · QA de navegador",
+            artifact: "Artefacte estàtic validat",
+            targets: ["GitHub Pages", "Docker / Nginx"],
+          },
           href: links.portfolio,
           secondaryHref: "",
           secondaryLabel: "",
@@ -1533,6 +1554,31 @@ export default function Home() {
                     </figure>
                   ) : null}
                   <p className="project-summary">{project.summary}</p>
+
+                  {"delivery" in project ? (
+                    <figure className="delivery-map">
+                      <figcaption>{project.delivery.label}</figcaption>
+                      <div className="delivery-flow">
+                        <div className="delivery-node">
+                          <span>01 / SOURCE</span>
+                          <strong>{project.delivery.source}</strong>
+                        </div>
+                        <div className="delivery-node">
+                          <span>02 / VERIFY</span>
+                          <strong>{project.delivery.checks}</strong>
+                        </div>
+                        <div className="delivery-node is-artifact">
+                          <span>03 / PACKAGE</span>
+                          <strong>{project.delivery.artifact}</strong>
+                        </div>
+                        <div className="delivery-targets">
+                          {project.delivery.targets.map((target) => (
+                            <span key={target}>{target}</span>
+                          ))}
+                        </div>
+                      </div>
+                    </figure>
+                  ) : null}
 
                   {"pipeline" in project ? (
                     <figure className="project-pipeline">


### PR DESCRIPTION
## Summary

- add the same delivery architecture diagram published on the Sites portfolio
- explain the reproducible flow from source through validation to one static artifact
- show GitHub Pages and Docker/Nginx as equivalent deployment targets
- provide localized copy in English, Spanish, and Catalan
- balance the portfolio project card without adding decorative filler

## Mirror guarantee

The React markup and localized content in `app/page.tsx` match the Sites source exactly. The diagram CSS is reproduced in the GitHub static-export codebase while preserving its existing platform-specific visual layer.

## Validation

- `git diff --check`
- `npm run lint`
- `npm test`
- Next.js static export completed
- 8 public deployment artifacts validated