### PR TITLE
Mirror live project briefs with static compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JimBLogic cybersecurity portfolio
 
-Recruiter-first portfolio for Jaime Ramsden de Frutos, focused on verifiable Junior SOC / Blue Team proof of work. It mirrors the current ChatGPT Sites design, supports English, Spanish and Catalan, and builds as one static artifact for GitHub Pages or self-hosting.
+Recruiter-first portfolio for Jaime Ramsden de Frutos, focused on verifiable Junior SOC / Blue Team proof of work. This repository is the public, reproducible compatibility source for the GitHub Pages edition and the ChatGPT Sites mirror. It supports English, Spanish and Catalan and produces one static artifact for GitHub Pages or self-hosting.
 
 ## Quick start
 
@@ -19,6 +19,7 @@ Open `http://localhost:3000`.
 |---|---|
 | `app/` | Next.js routes, portfolio content, SEO and styling |
 | `app/certifications/` | Searchable certification explorer |
+| `app/labs/` | Portable project briefs and gateways to the live applications |
 | `public/images/` | Production portfolio imagery |
 | `public/documents/` | Stable public CV and certificate routes |
 | `docs/` | Architecture, development, deployment and rollback guides |
@@ -35,6 +36,8 @@ Files such as `package.json`, `next.config.ts`, `tsconfig.json`, PostCSS and ESL
 npm run dev       # local development
 npm run lint      # source checks
 npm test          # production build + artifact validation
+npm run build:compat  # generate the portable static out/ artifact
+npm run verify:mirror # lint, build and validate every mirrored route
 npm run start     # preview the generated out/ directory
 ```
 
@@ -43,11 +46,14 @@ npm run start     # preview the generated out/ directory
 - [Architecture and content map](docs/ARCHITECTURE.md)
 - [Development and validation](docs/DEVELOPMENT.md)
 - [GitHub Pages and self-hosting](docs/DEPLOYMENT.md)
+- [Compatibility and mirror contract](docs/COMPATIBILITY.md)
 
 ## Live versions
 
 - GitHub Pages: <https://jimblogic.github.io/>
 - ChatGPT Sites mirror: <https://jimblogic-portfolio-lab.jimblogic.chatgpt.site/>
+
+The portable UI, translations and lab routes are kept equivalent across both editions. Platform adapters remain separate: GitHub uses a static Next.js export, while Sites uses its Cloudflare-compatible runtime.
 
 ## Rollback archive
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -686,6 +686,44 @@ main section[id] {
     var(--ink-raised);
 }
 
+.project-card.is-wide {
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: minmax(0, 1.05fr) minmax(360px, 0.95fr);
+  column-gap: clamp(44px, 7vw, 110px);
+}
+
+.project-card.is-wide .project-topline {
+  grid-column: 1 / -1;
+}
+
+.project-card.is-wide h3 {
+  grid-column: 1;
+  grid-row: 2;
+}
+
+.project-card.is-wide .project-summary {
+  grid-column: 1;
+  grid-row: 3;
+}
+
+.project-card.is-wide .project-metrics {
+  align-self: end;
+  grid-column: 2;
+  grid-row: 2;
+}
+
+.project-card.is-wide .project-notes {
+  grid-column: 2;
+  grid-row: 3;
+  margin-top: 24px;
+}
+
+.project-card.is-wide .project-actions {
+  grid-column: 1 / -1;
+  grid-row: 4;
+}
+
 .project-topline {
   display: flex;
   align-items: center;
@@ -794,7 +832,7 @@ main section[id] {
 
 .delivery-targets {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .delivery-targets span {
@@ -1618,6 +1656,11 @@ footer p:last-child {
     grid-row: auto;
   }
 
+  .project-card.is-wide {
+    display: flex;
+    grid-column: auto;
+  }
+
   .credential-list > a {
     grid-template-columns: 64px minmax(0, 1fr) 70px;
   }
@@ -2085,11 +2128,589 @@ footer {
   .evidence-rail { display: block; }
   .avatar-frame { width: 140px; }
   .proof-path, .section, .contact-section { border-radius: 18px; }
+  .delivery-targets { grid-template-columns: 1fr; }
+  .delivery-targets span + span { border-top: 1px solid var(--rule); border-left: 0; }
 }
 
 @media (prefers-reduced-motion: reduce) {
   body::before,
   body::after {
     animation: none !important;
+  }
+}
+
+/* Internal project gateways keep live apps connected to the portfolio without
+   attempting cross-origin framing that the deployed apps intentionally deny. */
+.lab-site-shell {
+  min-height: calc(100vh - 28px);
+}
+
+.lab-header-panel,
+.lab-header-panel nav {
+  display: flex;
+  align-items: center;
+}
+
+.lab-header-panel {
+  gap: clamp(24px, 4vw, 58px);
+}
+
+.lab-header-panel nav {
+  gap: 26px;
+  color: var(--paper-dim);
+  font-size: 13px;
+}
+
+.lab-header-panel nav a {
+  transition: color 160ms ease;
+}
+
+.lab-header-panel nav a:hover,
+.lab-header-panel nav a:focus-visible {
+  color: var(--orange);
+}
+
+.lab-main {
+  display: grid;
+  gap: 20px;
+  padding-top: 20px;
+}
+
+.lab-hero {
+  display: grid;
+  min-height: calc(100vh - 118px);
+  grid-template-columns: minmax(0, 1.1fr) minmax(380px, 0.9fr);
+  overflow: hidden;
+  border: 1px solid rgba(247, 147, 26, 0.22);
+  border-left: 4px solid var(--orange);
+  border-radius: 24px;
+  background:
+    radial-gradient(circle at 15% 10%, rgba(247, 147, 26, 0.09), transparent 34%),
+    rgba(35, 37, 38, 0.94);
+  box-shadow: 0 16px 44px rgba(0, 0, 0, 0.32);
+}
+
+.lab-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  justify-content: center;
+  padding: clamp(52px, 7vw, 104px) clamp(28px, 6vw, 88px);
+}
+
+.lab-breadcrumb {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 9px;
+  margin-bottom: clamp(48px, 7vw, 92px);
+  color: var(--steel);
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.lab-breadcrumb a:hover,
+.lab-breadcrumb a:focus-visible {
+  color: var(--orange);
+}
+
+.lab-status-line {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin-bottom: 16px;
+  color: var(--green);
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.lab-status-line .status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--green);
+  box-shadow: 0 0 0 4px rgba(155, 214, 164, 0.1);
+}
+
+.lab-copy .eyebrow {
+  margin: 0;
+}
+
+.lab-copy h1 {
+  max-width: 920px;
+  margin: 18px 0 0;
+  font-size: clamp(46px, 6vw, 92px);
+  font-weight: 700;
+  letter-spacing: -0.06em;
+  line-height: 0.96;
+}
+
+.lab-statement {
+  max-width: 780px;
+  margin: 34px 0 0;
+  color: var(--paper);
+  font-size: clamp(20px, 2vw, 30px);
+  font-weight: 500;
+  letter-spacing: -0.025em;
+  line-height: 1.3;
+}
+
+.lab-intro {
+  max-width: 740px;
+  margin: 22px 0 0;
+  color: var(--paper-dim);
+  font-size: 15px;
+  line-height: 1.78;
+}
+
+.lab-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 38px;
+}
+
+.lab-actions .button {
+  min-height: 48px;
+}
+
+.lab-actions-prominent {
+  display: grid;
+  align-items: stretch;
+  grid-template-columns: minmax(0, 1fr) auto;
+  margin-top: 34px;
+}
+
+.lab-live-launch {
+  display: grid;
+  min-width: 0;
+  min-height: 108px;
+  align-content: center;
+  grid-template-columns: minmax(0, 1fr) auto;
+  border: 1px solid var(--orange);
+  border-radius: 14px;
+  padding: 20px 22px;
+  background: var(--orange);
+  color: var(--ink);
+  box-shadow: 0 16px 40px rgba(247, 147, 26, 0.14);
+  transition:
+    background 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.lab-live-launch:hover,
+.lab-live-launch:focus-visible {
+  background: #ffad43;
+  box-shadow: 0 20px 54px rgba(247, 147, 26, 0.23);
+  transform: translateY(-2px);
+}
+
+.lab-live-launch > span:first-child {
+  color: rgba(8, 10, 13, 0.68);
+  font-family: var(--mono);
+  font-size: 8px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.lab-live-launch > strong {
+  display: block;
+  margin-top: 8px;
+  font-size: clamp(20px, 2.2vw, 30px);
+  letter-spacing: -0.035em;
+  line-height: 1.12;
+}
+
+.lab-live-launch > span:last-child {
+  display: flex;
+  grid-column: 2;
+  grid-row: 1 / 3;
+  align-items: center;
+  padding-left: 18px;
+  font-size: 22px;
+  transition: transform 180ms ease;
+}
+
+.lab-live-launch:hover > span:last-child {
+  transform: translate(3px, -3px);
+}
+
+.lab-repo-link {
+  display: inline-flex;
+  min-height: 48px;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  border: 1px solid var(--rule-bright);
+  border-radius: 12px;
+  padding: 14px 18px;
+  color: var(--paper-dim);
+  font-size: 11px;
+  font-weight: 600;
+  transition: border-color 180ms ease, color 180ms ease;
+}
+
+.lab-repo-link:hover,
+.lab-repo-link:focus-visible {
+  border-color: var(--orange);
+  color: var(--orange);
+}
+
+.lab-new-tab {
+  max-width: 610px;
+  margin: 15px 0 0;
+  color: var(--steel);
+  font-family: var(--mono);
+  font-size: 9px;
+  line-height: 1.6;
+}
+
+.lab-access-card {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  justify-content: center;
+  border-left: 1px solid var(--rule);
+  padding: clamp(28px, 4vw, 62px);
+  background:
+    linear-gradient(150deg, rgba(247, 147, 26, 0.055), transparent 55%),
+    rgba(8, 10, 13, 0.48);
+}
+
+.lab-access-topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  color: var(--steel);
+  font-family: var(--mono);
+  font-size: 8px;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.lab-access-topline > span {
+  color: var(--orange);
+}
+
+.lab-access-topline strong {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--green);
+  font-weight: 500;
+}
+
+.lab-access-topline i {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--green);
+  box-shadow: 0 0 0 4px rgba(155, 214, 164, 0.1);
+}
+
+.lab-access-card > h2 {
+  max-width: 640px;
+  margin: clamp(42px, 6vw, 82px) 0 0;
+  font-size: clamp(34px, 4vw, 58px);
+  letter-spacing: -0.05em;
+  line-height: 1.02;
+}
+
+.lab-access-card > p {
+  max-width: 650px;
+  margin: 22px 0 0;
+  color: var(--paper-dim);
+  font-size: 14px;
+  line-height: 1.75;
+}
+
+.lab-metrics {
+  display: grid;
+  margin: 22px 0 0;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+}
+
+.lab-metrics > div {
+  min-width: 0;
+  padding: 20px 14px;
+}
+
+.lab-metrics > div + div {
+  border-left: 1px solid var(--rule);
+}
+
+.lab-metrics dt {
+  font-size: clamp(22px, 3vw, 34px);
+  font-weight: 600;
+  line-height: 1;
+}
+
+.lab-metrics dd {
+  margin: 8px 0 0;
+  color: var(--steel);
+  font-family: var(--mono);
+  font-size: 7px;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.lab-brief {
+  border: 1px solid rgba(247, 147, 26, 0.22);
+  border-left: 4px solid var(--orange);
+  border-radius: 24px;
+  padding: clamp(48px, 6vw, 82px) clamp(24px, 5vw, 76px);
+  background: rgba(35, 37, 38, 0.94);
+  box-shadow: 0 16px 44px rgba(0, 0, 0, 0.32);
+}
+
+.lab-brief .section-heading h2 {
+  font-size: clamp(38px, 5vw, 68px);
+}
+
+.lab-brief-grid {
+  display: grid;
+  margin-top: 38px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border-top: 1px solid var(--rule);
+  border-left: 1px solid var(--rule);
+}
+
+.lab-brief-grid article {
+  min-width: 0;
+  border-right: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  padding: clamp(26px, 3.2vw, 42px);
+  background: rgba(24, 26, 27, 0.58);
+}
+
+.lab-brief-grid article > span {
+  color: var(--orange);
+  font-family: var(--mono);
+  font-size: 9px;
+}
+
+.lab-brief-grid h3 {
+  margin: 24px 0 0;
+  font-size: clamp(21px, 2vw, 30px);
+  letter-spacing: -0.04em;
+}
+
+.lab-brief-grid p {
+  margin: 16px 0 0;
+  color: var(--paper-dim);
+  font-size: 13px;
+  line-height: 1.75;
+}
+
+.lab-next {
+  overflow: hidden;
+  border: 1px solid rgba(247, 147, 26, 0.22);
+  border-left: 4px solid var(--orange);
+  border-radius: 20px;
+  background: rgba(35, 37, 38, 0.94);
+}
+
+.lab-next > a {
+  display: flex;
+  width: 100%;
+  min-height: 44px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 30px;
+  padding: clamp(25px, 4vw, 42px);
+  color: inherit;
+  transition: background 180ms ease;
+}
+
+.lab-next > a:hover,
+.lab-next > a:focus-visible {
+  background: rgba(247, 147, 26, 0.055);
+}
+
+.lab-next > a div > span {
+  display: block;
+  color: var(--steel);
+  font-family: var(--mono);
+  font-size: 8px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.lab-next > a strong {
+  display: block;
+  margin-top: 8px;
+  color: var(--paper);
+  font-size: clamp(20px, 2vw, 30px);
+}
+
+.lab-next-action {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  gap: 14px;
+  color: var(--orange);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.lab-next-action > span,
+.lab-footer > a:last-child span {
+  transition: transform 180ms ease;
+}
+
+.lab-next > a:hover .lab-next-action > span,
+.lab-footer > a:last-child:hover span {
+  transform: translateX(4px);
+}
+
+.lab-footer {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 28px;
+}
+
+.lab-footer p {
+  margin: 0;
+  color: var(--steel);
+  font-size: 11px;
+  text-align: center;
+}
+
+.lab-footer > a:last-child {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--orange);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+@media (max-width: 1050px) {
+  .lab-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .lab-access-card {
+    border-top: 1px solid var(--rule);
+    border-left: 0;
+  }
+}
+
+@media (max-width: 720px) {
+  .lab-header {
+    gap: 12px;
+  }
+
+  .lab-header-panel nav {
+    display: none;
+  }
+
+  .lab-header-panel {
+    gap: 10px;
+  }
+
+  .lab-header .languages {
+    gap: 11px;
+  }
+
+  .lab-header .languages button {
+    min-width: 30px;
+    min-height: 42px;
+  }
+
+  .lab-main {
+    padding-top: 12px;
+  }
+
+  .lab-hero,
+  .lab-brief {
+    border-radius: 18px;
+  }
+
+  .lab-copy {
+    padding: 50px 24px;
+  }
+
+  .lab-breadcrumb {
+    margin-bottom: 46px;
+  }
+
+  .lab-copy h1 {
+    font-size: clamp(42px, 13vw, 64px);
+  }
+
+  .lab-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .lab-actions-prominent {
+    display: flex;
+  }
+
+  .lab-actions .button {
+    justify-content: center;
+  }
+
+  .lab-access-card {
+    padding: 24px 18px 32px;
+  }
+
+  .lab-access-card > h2 {
+    margin-top: 42px;
+  }
+
+  .lab-brief {
+    padding: 54px 20px;
+  }
+
+  .lab-brief-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .lab-next {
+    border-radius: 16px;
+  }
+
+  .lab-next > a {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .lab-footer {
+    grid-template-columns: 1fr;
+    text-align: left;
+  }
+
+  .lab-footer p {
+    text-align: left;
+  }
+}
+
+@media (max-width: 430px) {
+  .lab-header .wordmark {
+    font-size: 18px;
+  }
+
+  .lab-header .languages {
+    gap: 6px;
+  }
+
+  .lab-header .languages button {
+    min-width: 27px;
+    font-size: 10px;
+  }
+
+  .lab-metrics > div {
+    padding: 18px 9px;
   }
 }

--- a/app/labs/LabPage.tsx
+++ b/app/labs/LabPage.tsx
@@ -1,0 +1,549 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+type Language = "en" | "es" | "ca";
+export type LabId = "cyberdailylog" | "austrian-monitor";
+
+const labConfig = {
+  cyberdailylog: {
+    code: "INTEL / 01",
+    liveUrl: "https://cyberdailylog-dashboard.jimblogic.chatgpt.site",
+    repoUrl: "https://github.com/JimBLogic/CyberDailyLog",
+    sibling: "austrian-monitor" as LabId,
+    siblingPath: "/labs/austrian-monitor",
+  },
+  "austrian-monitor": {
+    code: "MACRO / 02",
+    liveUrl:
+      "https://austrian-business-cycle-monitor.jimblogic.chatgpt.site",
+    repoUrl: "https://github.com/JimBLogic/AustrianBusinessCycleMonitor",
+    sibling: "cyberdailylog" as LabId,
+    siblingPath: "/labs/cyberdailylog",
+  },
+} as const;
+
+const copy = {
+  en: {
+    skip: "Skip to project",
+    portfolio: "Portfolio",
+    projects: "All projects",
+    status: "Public live demo",
+    gateway: "Live project gateway",
+    open: "View the complete live application",
+    repo: "Inspect repository",
+    back: "Back to portfolio",
+    keepOpen:
+      "The live application opens in a new tab, so this portfolio context stays open.",
+    context: "What you are opening",
+    briefEyebrow: "Project brief",
+    briefTitle: "Three things worth knowing.",
+    find: "What you’ll find",
+    shows: "What it demonstrates",
+    relationship: "Why it belongs here",
+    purpose: "Purpose",
+    inside: "Inside the system",
+    review: "A useful review path",
+    boundary: "Boundary",
+    other: "Continue to the other field lab",
+    footer: "Built as auditable, practical proof of work.",
+    projectsCopy: {
+      cyberdailylog: {
+        title: "CyberDailyLog",
+        eyebrow: "Blue Team intelligence system",
+        statement:
+          "From source validation to an analyst-ready daily defensive brief.",
+        intro:
+          "A live interface for the automated pipeline behind my daily threat-intelligence work: qualified developments, source health, prioritisation and exportable evidence in one reviewable surface.",
+        purposeText:
+          "Reduce noisy public security information into a concise, source-backed starting point for defensive triage without hiding freshness, confidence or methodology.",
+        insideItems: [
+          "Normalised CVE, KEV and EPSS context",
+          "Source-health and pipeline status",
+          "Thirty-day history plus JSON/CSV exports",
+          "Bilingual methodology and watchlist views",
+        ],
+        reviewItems: [
+          "Check the timestamp and source quorum",
+          "Open a qualified development",
+          "Trace why it crossed the threshold",
+          "Inspect the export and repository evidence",
+        ],
+        boundaryText:
+          "A defensive research and learning project. It supports analyst review; it does not replace organisational telemetry, enrichment or human escalation decisions.",
+        metrics: [
+          ["24 h", "rolling window"],
+          ["CVE", "KEV + EPSS"],
+          ["3/3", "core sources"],
+        ],
+        accessTitle: "The working system, one click away",
+        accessLead:
+          "This page is only a short project brief. Continue to the real deployed dashboard for the complete experience.",
+        findText:
+          "A live 24-hour defensive brief, qualified developments, source health, a 30-day history, watchlists and JSON/CSV exports.",
+        showsText:
+          "Source validation, Python automation, data normalisation, prioritisation, documentation and bilingual product delivery.",
+        relationshipText:
+          "My main Blue Team experimentation project. It turns daily learning into an auditable analyst workflow aligned with the SOC role I am targeting.",
+        accessItems: [
+          ["Live dashboard", "Qualified developments, history and source health"],
+          ["Public evidence", "Exports, methodology and source repository"],
+          ["Review order", "Freshness → threshold → source trace"],
+        ],
+      },
+      "austrian-monitor": {
+        title: "Austrian Business Cycle Monitor",
+        eyebrow: "Macro research system",
+        statement:
+          "A transparent macro lens for liquidity, credit and business-cycle conditions.",
+        intro:
+          "A live analytical dashboard that makes its data layers, source health and divergences visible instead of collapsing a complex cycle into a single magic number.",
+        purposeText:
+          "Organise macro signals through an Austrian-economics framework while preserving the distinction between observed data, interpretation and educational context.",
+        insideItems: [
+          "Liquidity, credit and market-structure pillars",
+          "Productive-activity and market indicators",
+          "Visible source freshness and fallback states",
+          "Educational insights, tooltips and annotations",
+        ],
+        reviewItems: [
+          "Start with data freshness and source health",
+          "Compare the three analytical pillars",
+          "Inspect explicit signal divergences",
+          "Read the methodology before drawing conclusions",
+        ],
+        boundaryText:
+          "An educational monitoring and research tool, not investment advice, a forecast engine or an instruction to trade.",
+        metrics: [
+          ["3", "signal pillars"],
+          ["MACRO", "economic indicators"],
+          ["LIVE", "data health"],
+        ],
+        accessTitle: "The working monitor, one click away",
+        accessLead:
+          "This page is only a short project brief. Continue to the real deployed macro dashboard for the complete experience.",
+        findText:
+          "Macro indicators organised around liquidity, credit, productive activity and market structure, with source health and methodology visible.",
+        showsText:
+          "Full-stack dashboarding, API integration, data provenance, resilient fallbacks and interpretation without false precision.",
+        relationshipText:
+          "A personal interest in Austrian economics turned into a technical product. It shows that I can apply rigorous data and product thinking beyond a single domain.",
+        accessItems: [
+          ["Live dashboard", "Macro indicators, cycle signals and data health"],
+          ["Public evidence", "Methodology, source states and repository"],
+          ["Review order", "Freshness → pillars → divergences"],
+        ],
+      },
+    },
+  },
+  es: {
+    skip: "Saltar al proyecto",
+    portfolio: "Portfolio",
+    projects: "Todos los proyectos",
+    status: "Demo pública activa",
+    gateway: "Acceso al proyecto en vivo",
+    open: "Ver la web completa",
+    repo: "Revisar repositorio",
+    back: "Volver al portfolio",
+    keepOpen:
+      "La aplicación en vivo se abre en una pestaña nueva, por lo que este contexto del portfolio permanece abierto.",
+    context: "Qué vas a abrir",
+    briefEyebrow: "Resumen del proyecto",
+    briefTitle: "Tres cosas que merece la pena saber.",
+    find: "Qué encontrarás",
+    shows: "Qué demuestra",
+    relationship: "Por qué encaja aquí",
+    purpose: "Propósito",
+    inside: "Dentro del sistema",
+    review: "Una ruta útil de revisión",
+    boundary: "Límite",
+    other: "Continuar al otro laboratorio",
+    footer: "Construido como evidencia práctica auditable.",
+    projectsCopy: {
+      cyberdailylog: {
+        title: "CyberDailyLog",
+        eyebrow: "Sistema de inteligencia Blue Team",
+        statement:
+          "De la validación de fuentes a un informe defensivo diario listo para el analista.",
+        intro:
+          "Una interfaz viva para el pipeline automatizado que sostiene mi trabajo diario de inteligencia de amenazas: novedades cualificadas, salud de fuentes, priorización y evidencia exportable en una superficie revisable.",
+        purposeText:
+          "Reducir el ruido de la información pública de seguridad a un punto de partida conciso y respaldado por fuentes para el triaje defensivo, sin ocultar actualidad, confianza o metodología.",
+        insideItems: [
+          "Contexto normalizado de CVE, KEV y EPSS",
+          "Salud de fuentes y estado del pipeline",
+          "Histórico de 30 días y exportación JSON/CSV",
+          "Metodología bilingüe y vistas de watchlist",
+        ],
+        reviewItems: [
+          "Comprobar timestamp y cuórum de fuentes",
+          "Abrir una novedad cualificada",
+          "Seguir por qué superó el umbral",
+          "Revisar la exportación y la evidencia del repositorio",
+        ],
+        boundaryText:
+          "Proyecto defensivo de investigación y aprendizaje. Ayuda a la revisión del analista; no sustituye telemetría interna, enriquecimiento ni decisiones humanas de escalado.",
+        metrics: [
+          ["24 h", "ventana móvil"],
+          ["CVE", "KEV + EPSS"],
+          ["3/3", "fuentes núcleo"],
+        ],
+        accessTitle: "El sistema real, a un clic",
+        accessLead:
+          "Esta página es solo un resumen breve. Continúa al dashboard real desplegado para ver la experiencia completa.",
+        findText:
+          "Un informe defensivo vivo de 24 horas, novedades cualificadas, salud de fuentes, histórico de 30 días, watchlists y exportaciones JSON/CSV.",
+        showsText:
+          "Validación de fuentes, automatización con Python, normalización de datos, priorización, documentación y entrega bilingüe de producto.",
+        relationshipText:
+          "Mi principal proyecto de experimentación Blue Team. Convierte el aprendizaje diario en un flujo de analista auditable y alineado con el puesto SOC al que aspiro.",
+        accessItems: [
+          ["Dashboard en vivo", "Novedades cualificadas, histórico y salud de fuentes"],
+          ["Evidencia pública", "Exportaciones, metodología y repositorio"],
+          ["Orden de revisión", "Actualidad → umbral → trazabilidad de fuente"],
+        ],
+      },
+      "austrian-monitor": {
+        title: "Austrian Business Cycle Monitor",
+        eyebrow: "Sistema de investigación macro",
+        statement:
+          "Una lente macro transparente para liquidez, crédito y condiciones del ciclo económico.",
+        intro:
+          "Un dashboard analítico vivo que hace visibles sus capas de datos, salud de fuentes y divergencias, en vez de reducir un ciclo complejo a un único número mágico.",
+        purposeText:
+          "Organizar señales macro mediante un marco de economía austriaca, manteniendo la distinción entre datos observados, interpretación y contexto educativo.",
+        insideItems: [
+          "Pilares de liquidez, crédito y estructura de mercado",
+          "Indicadores de actividad productiva y mercados",
+          "Actualidad de fuentes y fallbacks visibles",
+          "Insights educativos, tooltips y anotaciones",
+        ],
+        reviewItems: [
+          "Empezar por actualidad y salud de fuentes",
+          "Comparar los tres pilares analíticos",
+          "Revisar las divergencias explícitas",
+          "Leer la metodología antes de concluir",
+        ],
+        boundaryText:
+          "Herramienta educativa de monitorización e investigación; no es asesoramiento financiero, motor de predicción ni instrucción para operar.",
+        metrics: [
+          ["3", "pilares de señal"],
+          ["MACRO", "indicadores económicos"],
+          ["LIVE", "salud de datos"],
+        ],
+        accessTitle: "El monitor real, a un clic",
+        accessLead:
+          "Esta página es solo un resumen breve. Continúa al dashboard macro real desplegado para ver la experiencia completa.",
+        findText:
+          "Indicadores macro organizados en torno a liquidez, crédito, actividad productiva y estructura de mercado, con salud de fuentes y metodología visibles.",
+        showsText:
+          "Desarrollo full-stack de dashboards, integración de APIs, procedencia de datos, fallbacks resilientes e interpretación sin falsa precisión.",
+        relationshipText:
+          "Un interés personal por la economía austriaca convertido en producto técnico. Demuestra que aplico rigor de datos y criterio de producto más allá de un único ámbito.",
+        accessItems: [
+          ["Dashboard en vivo", "Indicadores macro, señales de ciclo y salud de datos"],
+          ["Evidencia pública", "Metodología, estados de fuentes y repositorio"],
+          ["Orden de revisión", "Actualidad → pilares → divergencias"],
+        ],
+      },
+    },
+  },
+  ca: {
+    skip: "Saltar al projecte",
+    portfolio: "Portfolio",
+    projects: "Tots els projectes",
+    status: "Demo pública activa",
+    gateway: "Accés al projecte en viu",
+    open: "Veure el web complet",
+    repo: "Revisar repositori",
+    back: "Tornar al portfolio",
+    keepOpen:
+      "L’aplicació en viu s’obre en una pestanya nova, de manera que aquest context del portfolio queda obert.",
+    context: "Què obriràs",
+    briefEyebrow: "Resum del projecte",
+    briefTitle: "Tres coses que val la pena saber.",
+    find: "Què hi trobaràs",
+    shows: "Què demostra",
+    relationship: "Per què encaixa aquí",
+    purpose: "Propòsit",
+    inside: "Dins del sistema",
+    review: "Una ruta útil de revisió",
+    boundary: "Límit",
+    other: "Continuar a l’altre laboratori",
+    footer: "Construït com a evidència pràctica auditable.",
+    projectsCopy: {
+      cyberdailylog: {
+        title: "CyberDailyLog",
+        eyebrow: "Sistema d’intel·ligència Blue Team",
+        statement:
+          "De la validació de fonts a un informe defensiu diari llest per a l’analista.",
+        intro:
+          "Una interfície viva per al pipeline automatitzat que sosté la meva feina diària d’intel·ligència d’amenaces: novetats qualificades, salut de fonts, priorització i evidència exportable en una superfície revisable.",
+        purposeText:
+          "Reduir el soroll de la informació pública de seguretat a un punt de partida concís i basat en fonts per al triatge defensiu, sense ocultar actualitat, confiança o metodologia.",
+        insideItems: [
+          "Context normalitzat de CVE, KEV i EPSS",
+          "Salut de fonts i estat del pipeline",
+          "Històric de 30 dies i exportació JSON/CSV",
+          "Metodologia bilingüe i vistes de watchlist",
+        ],
+        reviewItems: [
+          "Comprovar timestamp i quòrum de fonts",
+          "Obrir una novetat qualificada",
+          "Seguir per què ha superat el llindar",
+          "Revisar l’exportació i l’evidència del repositori",
+        ],
+        boundaryText:
+          "Projecte defensiu de recerca i aprenentatge. Ajuda la revisió de l’analista; no substitueix telemetria interna, enriquiment ni decisions humanes d’escalat.",
+        metrics: [
+          ["24 h", "finestra mòbil"],
+          ["CVE", "KEV + EPSS"],
+          ["3/3", "fonts nucli"],
+        ],
+        accessTitle: "El sistema real, a un clic",
+        accessLead:
+          "Aquesta pàgina és només un resum breu. Continua al dashboard real desplegat per veure l’experiència completa.",
+        findText:
+          "Un informe defensiu viu de 24 hores, novetats qualificades, salut de fonts, històric de 30 dies, watchlists i exportacions JSON/CSV.",
+        showsText:
+          "Validació de fonts, automatització amb Python, normalització de dades, priorització, documentació i lliurament bilingüe de producte.",
+        relationshipText:
+          "El meu principal projecte d’experimentació Blue Team. Converteix l’aprenentatge diari en un flux d’analista auditable i alineat amb el lloc SOC al qual aspiro.",
+        accessItems: [
+          ["Dashboard en viu", "Novetats qualificades, històric i salut de fonts"],
+          ["Evidència pública", "Exportacions, metodologia i repositori"],
+          ["Ordre de revisió", "Actualitat → llindar → traçabilitat de font"],
+        ],
+      },
+      "austrian-monitor": {
+        title: "Austrian Business Cycle Monitor",
+        eyebrow: "Sistema de recerca macro",
+        statement:
+          "Una lent macro transparent per a liquiditat, crèdit i condicions del cicle econòmic.",
+        intro:
+          "Un dashboard analític viu que mostra les capes de dades, la salut de les fonts i les divergències, en lloc de reduir un cicle complex a un únic número màgic.",
+        purposeText:
+          "Organitzar senyals macro mitjançant un marc d’economia austríaca, mantenint la distinció entre dades observades, interpretació i context educatiu.",
+        insideItems: [
+          "Pilars de liquiditat, crèdit i estructura de mercat",
+          "Indicadors d’activitat productiva i mercats",
+          "Actualitat de fonts i fallbacks visibles",
+          "Insights educatius, tooltips i anotacions",
+        ],
+        reviewItems: [
+          "Començar per actualitat i salut de fonts",
+          "Comparar els tres pilars analítics",
+          "Revisar les divergències explícites",
+          "Llegir la metodologia abans de concloure",
+        ],
+        boundaryText:
+          "Eina educativa de monitoratge i recerca; no és assessorament financer, motor de predicció ni instrucció per operar.",
+        metrics: [
+          ["3", "pilars de senyal"],
+          ["MACRO", "indicadors econòmics"],
+          ["LIVE", "salut de dades"],
+        ],
+        accessTitle: "El monitor real, a un clic",
+        accessLead:
+          "Aquesta pàgina és només un resum breu. Continua al dashboard macro real desplegat per veure l’experiència completa.",
+        findText:
+          "Indicadors macro organitzats al voltant de liquiditat, crèdit, activitat productiva i estructura de mercat, amb salut de fonts i metodologia visibles.",
+        showsText:
+          "Desenvolupament full-stack de dashboards, integració d’APIs, procedència de dades, fallbacks resilients i interpretació sense falsa precisió.",
+        relationshipText:
+          "Un interès personal per l’economia austríaca convertit en producte tècnic. Demostra que aplico rigor de dades i criteri de producte més enllà d’un únic àmbit.",
+        accessItems: [
+          ["Dashboard en viu", "Indicadors macro, senyals de cicle i salut de dades"],
+          ["Evidència pública", "Metodologia, estats de fonts i repositori"],
+          ["Ordre de revisió", "Actualitat → pilars → divergències"],
+        ],
+      },
+    },
+  },
+} as const;
+
+function Arrow() {
+  return <span aria-hidden="true">↗</span>;
+}
+
+export default function LabPage({ lab }: { lab: LabId }) {
+  const [language, setLanguage] = useState<Language>("en");
+  const config = labConfig[lab];
+  const t = copy[language];
+  const project = t.projectsCopy[lab];
+  const sibling = t.projectsCopy[config.sibling];
+
+  useEffect(() => {
+    let timer: number | undefined;
+    try {
+      const saved = window.localStorage.getItem(
+        "jimblogic-language",
+      ) as Language | null;
+      if (saved && saved in copy) {
+        timer = window.setTimeout(() => setLanguage(saved), 0);
+      }
+    } catch {
+      // The page remains usable when storage is blocked.
+    }
+    return () => {
+      if (timer) window.clearTimeout(timer);
+    };
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.lang = language;
+    try {
+      window.localStorage.setItem("jimblogic-language", language);
+    } catch {
+      // The selected language still applies to this visit.
+    }
+  }, [language]);
+
+  return (
+    <>
+      <a className="skip-link" href="#lab-main">
+        {t.skip}
+      </a>
+
+      <div className="site-shell lab-site-shell">
+        <header className="site-header lab-header">
+          <Link className="wordmark" href="/" aria-label="JimBLogic — home">
+            JimBLogic<span>.</span>
+          </Link>
+
+          <div className="lab-header-panel">
+            <nav aria-label="Project navigation">
+              <Link href="/#work">{t.projects}</Link>
+              <Link href="/">{t.portfolio}</Link>
+            </nav>
+            <div className="languages" aria-label="Language">
+              {(["en", "es", "ca"] as const).map((lang) => (
+                <button
+                  key={lang}
+                  type="button"
+                  className={language === lang ? "is-active" : ""}
+                  aria-pressed={language === lang}
+                  onClick={() => setLanguage(lang)}
+                >
+                  {lang.toUpperCase()}
+                </button>
+              ))}
+            </div>
+          </div>
+        </header>
+
+        <main id="lab-main" className="lab-main">
+          <section className="lab-hero" aria-labelledby="lab-title">
+            <div className="lab-copy">
+              <div className="lab-breadcrumb" aria-label="Breadcrumb">
+                <Link href="/">JimBLogic</Link>
+                <span aria-hidden="true">/</span>
+                <Link href="/#work">Labs</Link>
+                <span aria-hidden="true">/</span>
+                <span>{config.code}</span>
+              </div>
+
+              <div className="lab-status-line">
+                <span className="status-dot" aria-hidden="true" />
+                {t.status}
+              </div>
+              <p className="eyebrow">{t.gateway} · {project.eyebrow}</p>
+              <h1 id="lab-title">{project.title}</h1>
+              <p className="lab-statement">{project.statement}</p>
+              <p className="lab-intro">{project.intro}</p>
+            </div>
+
+            <aside className="lab-access-card" aria-labelledby="lab-access-title">
+              <div className="lab-access-topline">
+                <span>{config.code}</span>
+                <strong><i aria-hidden="true" /> {t.status}</strong>
+              </div>
+              <h2 id="lab-access-title">{project.accessTitle}</h2>
+              <p>{project.accessLead}</p>
+
+              <div className="lab-actions lab-actions-prominent">
+                <a
+                  className="lab-live-launch"
+                  href={config.liveUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <span>{t.status}</span>
+                  <strong>{t.open}</strong>
+                  <Arrow />
+                </a>
+                <a
+                  className="lab-repo-link"
+                  href={config.repoUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {t.repo} <Arrow />
+                </a>
+              </div>
+              <p className="lab-new-tab">{t.keepOpen}</p>
+
+              <dl className="lab-metrics">
+                {project.metrics.map(([value, label]) => (
+                  <div key={label}>
+                    <dt>{value}</dt>
+                    <dd>{label}</dd>
+                  </div>
+                ))}
+              </dl>
+            </aside>
+          </section>
+
+          <section className="lab-brief" aria-labelledby="lab-brief-title">
+            <div className="section-heading compact">
+              <p className="eyebrow">{t.briefEyebrow} · {config.code}</p>
+              <h2 id="lab-brief-title">{t.briefTitle}</h2>
+            </div>
+
+            <div className="lab-brief-grid">
+              <article>
+                <span>01</span>
+                <h3>{t.find}</h3>
+                <p>{project.findText}</p>
+              </article>
+              <article>
+                <span>02</span>
+                <h3>{t.shows}</h3>
+                <p>{project.showsText}</p>
+              </article>
+              <article>
+                <span>03</span>
+                <h3>{t.relationship}</h3>
+                <p>{project.relationshipText}</p>
+              </article>
+            </div>
+          </section>
+
+          <nav className="lab-next" aria-label="Related project">
+            <a
+              href={config.siblingPath}
+              aria-label={`${t.other}: ${sibling.title}`}
+            >
+              <div>
+                <span>{t.other}</span>
+                <strong>{sibling.title}</strong>
+              </div>
+              <span className="lab-next-action">
+                {sibling.eyebrow} <span aria-hidden="true">→</span>
+              </span>
+            </a>
+          </nav>
+        </main>
+
+        <footer className="lab-footer">
+          <Link className="wordmark" href="/">
+            JimBLogic<span>.</span>
+          </Link>
+          <p>{t.footer}</p>
+          <Link href="/">{t.back} <span aria-hidden="true">→</span></Link>
+        </footer>
+      </div>
+    </>
+  );
+}

--- a/app/labs/austrian-monitor/page.tsx
+++ b/app/labs/austrian-monitor/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+import LabPage from "../LabPage";
+
+export const metadata: Metadata = {
+  title: "Austrian Business Cycle Monitor Live Lab",
+  description:
+    "Explore the live Austrian Business Cycle Monitor from the JimBLogic portfolio.",
+  alternates: { canonical: "/labs/austrian-monitor" },
+};
+
+export default function AustrianMonitorLab() {
+  return <LabPage lab="austrian-monitor" />;
+}

--- a/app/labs/cyberdailylog/page.tsx
+++ b/app/labs/cyberdailylog/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+import LabPage from "../LabPage";
+
+export const metadata: Metadata = {
+  title: "CyberDailyLog Live Lab",
+  description:
+    "Explore the live CyberDailyLog intelligence dashboard from the JimBLogic portfolio.",
+  alternates: { canonical: "/labs/cyberdailylog" },
+};
+
+export default function CyberDailyLogLab() {
+  return <LabPage lab="cyberdailylog" />;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,8 +24,16 @@ const links = {
   cv: "https://jimblogic.github.io/documents/Jaime-Ramsden-de-Frutos-CV.pdf",
   email: "mailto:jrf91@pm.me",
   cyberDailyLog: "https://github.com/JimBLogic/CyberDailyLog",
+  cyberDailyLab: "/labs/cyberdailylog",
+  cyberDailyLive:
+    "https://cyberdailylog-dashboard.jimblogic.chatgpt.site",
   cyberDailyReport:
     "https://github.com/JimBLogic/CyberDailyLog/blob/main/reports/latest.md",
+  austrianMonitorLab: "/labs/austrian-monitor",
+  austrianMonitorLive:
+    "https://austrian-business-cycle-monitor.jimblogic.chatgpt.site",
+  austrianMonitorRepo:
+    "https://github.com/JimBLogic/AustrianBusinessCycleMonitor",
   homelab: "https://github.com/JimBLogic/defensive-homelab-blue-team",
   portfolio: "https://github.com/JimBLogic/jimblogic.github.io",
   blueTeam:
@@ -89,7 +97,7 @@ const content = {
           status: "Automated daily",
           detail: "Source-backed 24-hour pipeline",
           stamp: "LIVE FEED",
-          href: links.cyberDailyReport,
+          href: links.cyberDailyLab,
         },
         {
           name: "Defensive Homelab",
@@ -133,6 +141,7 @@ const content = {
       intro:
         "Each project states its purpose, current status and limits. No enterprise-SOC cosplay; just real, reviewable work and the next sensible improvement.",
       open: "Open project",
+      brief: "View project brief",
       report: "Read today’s brief",
       cards: [
         {
@@ -161,9 +170,9 @@ const content = {
               ["04", "Publish", "Checked report + portfolio snapshot"],
             ],
           },
-          href: links.cyberDailyLog,
-          secondaryHref: links.cyberDailyReport,
-          secondaryLabel: "Read today’s brief",
+          href: links.cyberDailyLab,
+          secondaryHref: links.cyberDailyLog,
+          secondaryLabel: "Inspect repository",
           featured: true,
         },
         {
@@ -206,15 +215,37 @@ const content = {
             "GitHub Pages deployment gated by validation",
           ],
           delivery: {
-            label: "One source, two identical delivery paths",
-            source: "Portfolio source",
-            checks: "Lint · build · browser QA",
-            artifact: "Validated static artifact",
-            targets: ["GitHub Pages", "Docker / Nginx"],
+            label: "One portable source, three compatible delivery paths",
+            source: "Public GitHub source",
+            checks: "Lint · static build · route QA",
+            artifact: "Reproducible compatibility build",
+            targets: ["GitHub Pages", "ChatGPT Sites", "Docker / Nginx"],
           },
           href: links.portfolio,
           secondaryHref: "",
           secondaryLabel: "",
+          featured: false,
+        },
+        {
+          index: "04",
+          kicker: "Economics + data provenance + product thinking",
+          title: "Austrian Business Cycle Monitor",
+          summary:
+            "A transparent macro dashboard that connects liquidity, credit conditions, productive activity and market structure through an Austrian-economics lens, while keeping source health and model limits visible.",
+          metrics: [
+            ["3", "analytical pillars"],
+            ["MACRO", "economic indicators"],
+            ["LIVE", "data health"],
+          ],
+          notes: [
+            "Liquidity, credit and market-structure layers",
+            "Productive-activity and market indicators",
+            "Visible divergence and data-freshness states",
+            "Educational analysis, not trading advice",
+          ],
+          href: links.austrianMonitorLab,
+          secondaryHref: links.austrianMonitorRepo,
+          secondaryLabel: "Inspect repository",
           featured: false,
         },
       ],
@@ -445,7 +476,7 @@ const content = {
           status: "Automatizado a diario",
           detail: "Pipeline de 24 horas basado en fuentes",
           stamp: "DATOS EN VIVO",
-          href: links.cyberDailyReport,
+          href: links.cyberDailyLab,
         },
         {
           name: "Homelab defensivo",
@@ -489,6 +520,7 @@ const content = {
       intro:
         "Cada proyecto declara su propósito, estado actual y límites. Nada de disfrazarse de SOC empresarial: trabajo real y revisable, con la siguiente mejora lógica a la vista.",
       open: "Abrir proyecto",
+      brief: "Ver resumen del proyecto",
       report: "Leer el informe de hoy",
       cards: [
         {
@@ -517,9 +549,9 @@ const content = {
               ["04", "Publicar", "Informe validado + snapshot del portfolio"],
             ],
           },
-          href: links.cyberDailyLog,
-          secondaryHref: links.cyberDailyReport,
-          secondaryLabel: "Leer el informe de hoy",
+          href: links.cyberDailyLab,
+          secondaryHref: links.cyberDailyLog,
+          secondaryLabel: "Revisar repositorio",
           featured: true,
         },
         {
@@ -562,15 +594,37 @@ const content = {
             "Despliegue en GitHub Pages condicionado a validación",
           ],
           delivery: {
-            label: "Una fuente, dos rutas de entrega idénticas",
-            source: "Código del portfolio",
-            checks: "Lint · build · QA de navegador",
-            artifact: "Artefacto estático validado",
-            targets: ["GitHub Pages", "Docker / Nginx"],
+            label: "Una fuente portable, tres rutas de entrega compatibles",
+            source: "Código público en GitHub",
+            checks: "Lint · build estática · QA de rutas",
+            artifact: "Build de compatibilidad reproducible",
+            targets: ["GitHub Pages", "ChatGPT Sites", "Docker / Nginx"],
           },
           href: links.portfolio,
           secondaryHref: "",
           secondaryLabel: "",
+          featured: false,
+        },
+        {
+          index: "04",
+          kicker: "Economía + procedencia de datos + producto",
+          title: "Austrian Business Cycle Monitor",
+          summary:
+            "Un dashboard macro transparente que conecta liquidez, condiciones de crédito, actividad productiva y estructura de mercado desde una óptica de economía austriaca, mostrando la salud de las fuentes y los límites del modelo.",
+          metrics: [
+            ["3", "pilares analíticos"],
+            ["MACRO", "indicadores económicos"],
+            ["LIVE", "salud de datos"],
+          ],
+          notes: [
+            "Capas de liquidez, crédito y estructura de mercado",
+            "Indicadores de actividad productiva y mercados",
+            "Estados visibles de divergencia y actualidad de datos",
+            "Análisis educativo, no asesoramiento financiero",
+          ],
+          href: links.austrianMonitorLab,
+          secondaryHref: links.austrianMonitorRepo,
+          secondaryLabel: "Revisar repositorio",
           featured: false,
         },
       ],
@@ -801,7 +855,7 @@ const content = {
           status: "Automatitzat diàriament",
           detail: "Pipeline de 24 hores basat en fonts",
           stamp: "DADES EN VIU",
-          href: links.cyberDailyReport,
+          href: links.cyberDailyLab,
         },
         {
           name: "Homelab defensiu",
@@ -845,6 +899,7 @@ const content = {
       intro:
         "Cada projecte declara el propòsit, l’estat actual i els límits. Res de disfressar-se de SOC empresarial: feina real i revisable, amb la següent millora lògica a la vista.",
       open: "Obrir projecte",
+      brief: "Veure resum del projecte",
       report: "Llegir l’informe d’avui",
       cards: [
         {
@@ -873,9 +928,9 @@ const content = {
               ["04", "Publicar", "Informe validat + snapshot del portfolio"],
             ],
           },
-          href: links.cyberDailyLog,
-          secondaryHref: links.cyberDailyReport,
-          secondaryLabel: "Llegir l’informe d’avui",
+          href: links.cyberDailyLab,
+          secondaryHref: links.cyberDailyLog,
+          secondaryLabel: "Revisar repositori",
           featured: true,
         },
         {
@@ -918,15 +973,37 @@ const content = {
             "Desplegament a GitHub Pages condicionat a validació",
           ],
           delivery: {
-            label: "Una font, dues rutes de lliurament idèntiques",
-            source: "Codi del portfolio",
-            checks: "Lint · build · QA de navegador",
-            artifact: "Artefacte estàtic validat",
-            targets: ["GitHub Pages", "Docker / Nginx"],
+            label: "Una font portable, tres rutes de lliurament compatibles",
+            source: "Codi públic a GitHub",
+            checks: "Lint · build estàtica · QA de rutes",
+            artifact: "Build de compatibilitat reproduïble",
+            targets: ["GitHub Pages", "ChatGPT Sites", "Docker / Nginx"],
           },
           href: links.portfolio,
           secondaryHref: "",
           secondaryLabel: "",
+          featured: false,
+        },
+        {
+          index: "04",
+          kicker: "Economia + procedència de dades + producte",
+          title: "Austrian Business Cycle Monitor",
+          summary:
+            "Un dashboard macro transparent que connecta liquiditat, condicions de crèdit, activitat productiva i estructura de mercat des d’una òptica d’economia austríaca, mostrant la salut de les fonts i els límits del model.",
+          metrics: [
+            ["3", "pilars analítics"],
+            ["MACRO", "indicadors econòmics"],
+            ["LIVE", "salut de dades"],
+          ],
+          notes: [
+            "Capes de liquiditat, crèdit i estructura de mercat",
+            "Indicadors d’activitat productiva i mercats",
+            "Estats visibles de divergència i actualitat de dades",
+            "Anàlisi educativa, no assessorament financer",
+          ],
+          href: links.austrianMonitorLab,
+          secondaryHref: links.austrianMonitorRepo,
+          secondaryLabel: "Revisar repositori",
           featured: false,
         },
       ],
@@ -1482,8 +1559,12 @@ export default function Home() {
               {heroSignals.map((signal, index) => (
                 <a
                   href={signal.href}
-                  target="_blank"
-                  rel="noopener noreferrer"
+                  target={signal.href.startsWith("/") ? undefined : "_blank"}
+                  rel={
+                    signal.href.startsWith("/")
+                      ? undefined
+                      : "noopener noreferrer"
+                  }
                   className="signal"
                   key={signal.name}
                 >
@@ -1528,7 +1609,7 @@ export default function Home() {
             <div className="work-grid">
               {workCards.map((project) => (
                 <article
-                  className={`project-card ${project.featured ? "is-featured" : ""}`}
+                  className={`project-card ${project.featured ? "is-featured" : ""} ${project.index === "04" ? "is-wide" : ""}`}
                   key={project.title}
                 >
                   <div className="project-topline">
@@ -1611,8 +1692,16 @@ export default function Home() {
                   </ul>
 
                   <div className="project-actions">
-                    <a href={project.href} target="_blank" rel="noopener noreferrer">
-                      {t.work.open} <Arrow />
+                    <a
+                      href={project.href}
+                      target={project.href.startsWith("/") ? undefined : "_blank"}
+                      rel={
+                        project.href.startsWith("/")
+                          ? undefined
+                          : "noopener noreferrer"
+                      }
+                    >
+                      {project.href.startsWith("/") ? t.work.brief : t.work.open} <Arrow />
                     </a>
                     {project.secondaryHref ? (
                       <a

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -19,5 +19,17 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "monthly",
       priority: 0.8,
     },
+    {
+      url: `${siteUrl}/labs/cyberdailylog`,
+      lastModified,
+      changeFrequency: "weekly",
+      priority: 0.85,
+    },
+    {
+      url: `${siteUrl}/labs/austrian-monitor`,
+      lastModified,
+      changeFrequency: "weekly",
+      priority: 0.75,
+    },
   ];
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,10 +4,11 @@
 
 The portfolio uses Next.js 16, React 19 and TypeScript, but its production output is fully static. `next build` creates the deployable `out/` directory; no application server or database is required.
 
-The same artifact is used by both supported deployment paths:
+The compatibility artifact is used by the two portable deployment paths, while the same UI source is mirrored to Sites:
 
 1. GitHub Actions uploads `out/` to GitHub Pages.
 2. Docker copies `out/` into a small Nginx runtime image.
+3. ChatGPT Sites builds the equivalent routes with its Cloudflare-compatible Vinext adapter.
 
 This prevents the GitHub and self-hosted editions from drifting into separate applications.
 
@@ -17,6 +18,7 @@ This prevents the GitHub and self-hosted editions from drifting into separate ap
 - CyberDailyLog fetches its public GitHub snapshot in the browser and falls back safely to static portfolio data.
 - Language preference and the short-lived CyberDailyLog cache use browser storage only.
 - The certification explorer filters 37 verifiable records client-side.
+- Project briefs under `/labs/` are client-rendered, use only relative portfolio routes and open the full live applications explicitly in a new tab.
 - Images and public documents are served directly from `public/`.
 
 ## Content ownership
@@ -25,6 +27,7 @@ This prevents the GitHub and self-hosted editions from drifting into separate ap
 |---|---|
 | Main copy, projects and translations | `app/page.tsx` |
 | Certifications | `app/certifications/page.tsx` |
+| Project briefs and live-app gateways | `app/labs/` |
 | Responsive design | `app/globals.css` |
 | Certification design | `app/certifications/certifications.css` |
 | SEO and JSON-LD | `app/layout.tsx` |
@@ -38,6 +41,8 @@ The following paths are part of the public contract and must not be renamed with
 
 - `/`
 - `/certifications/`
+- `/labs/cyberdailylog/`
+- `/labs/austrian-monitor/`
 - `/robots.txt`
 - `/sitemap.xml`
 - `/manifest.webmanifest`

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,0 +1,49 @@
+# Compatibility and mirror contract
+
+## Canonical source
+
+This GitHub repository is the public, reproducible source for the portable portfolio interface. The ChatGPT Sites edition mirrors the same visible product surface: copy, translations, styles, project cards and the two `/labs/` routes.
+
+Platform-specific adapters are intentionally not forced into one configuration:
+
+| Target | Adapter | Output |
+|---|---|---|
+| GitHub Pages | Next.js static export | `out/` |
+| Docker / Nginx | The same static export | `out/` served by Nginx |
+| ChatGPT Sites | Vinext + Cloudflare-compatible Worker | Sites deployment artifact |
+
+This split keeps the interface portable without pretending that GitHub Pages can execute a Worker runtime.
+
+## Compatibility mode
+
+Run the complete portable verification path with:
+
+```bash
+npm ci
+npm run verify:mirror
+```
+
+`verify:mirror` lints the source, builds the static export and checks the homepage, certifications, both project briefs, crawl routes and stable public documents. The generated `out/` directory requires no Node.js server, database or secret at runtime.
+
+## Mirror scope
+
+The following paths must remain equivalent between GitHub and Sites:
+
+- `app/page.tsx`
+- `app/globals.css`
+- `app/labs/LabPage.tsx`
+- `app/labs/cyberdailylog/page.tsx`
+- `app/labs/austrian-monitor/page.tsx`
+- `public/llms.txt`
+
+Metadata bases, build configuration, hosting manifests and deployment helpers are adapter-specific and may differ.
+
+## Safe update sequence
+
+1. Update the portable interface in this repository.
+2. Run `npm run verify:mirror`.
+3. Review the generated routes locally with `npm run start`.
+4. Merge only after GitHub Actions passes.
+5. Apply the same portable-surface change to Sites and verify its deployment independently.
+
+No credentials, generated build directories or platform-owned deployment identifiers belong in the portable source.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -11,6 +11,8 @@ Both deployment methods serve the same generated `out/` directory.
 5. Verify:
    - <https://jimblogic.github.io/>
    - <https://jimblogic.github.io/certifications/>
+   - <https://jimblogic.github.io/labs/cyberdailylog/>
+   - <https://jimblogic.github.io/labs/austrian-monitor/>
    - <https://jimblogic.github.io/robots.txt>
    - <https://jimblogic.github.io/sitemap.xml>
 
@@ -43,7 +45,8 @@ The Nginx policy is stored in `infra/nginx/default.conf`.
 
 ```bash
 npm ci
-npm run build
+npm run build:compat
+npm run validate
 ```
 
 Serve `out/` using any static host. For a traditional Nginx server, copy the directory beneath your web root and adapt `infra/nginx/default.conf` to the chosen domain and filesystem path.

--- a/package.json
+++ b/package.json
@@ -8,10 +8,12 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "build:compat": "next build",
     "start": "npx serve@14 out",
     "lint": "eslint . --ignore-pattern .next --ignore-pattern out",
     "test": "npm run build && node scripts/validate-static.mjs",
-    "validate": "node scripts/validate-static.mjs"
+    "validate": "node scripts/validate-static.mjs",
+    "verify:mirror": "npm run lint && npm test"
   },
   "dependencies": {
     "next": "16.2.6",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -5,7 +5,9 @@
 ## Primary evidence
 
 - CyberDailyLog: automated, source-backed daily defensive intelligence with auditable reports — https://github.com/JimBLogic/CyberDailyLog
+- CyberDailyLog project brief and live-app gateway: /labs/cyberdailylog
 - Defensive Homelab: reproducible Raspberry Pi 4 Blue Team lab with LITE and FULL deployment modes — https://github.com/JimBLogic/defensive-homelab-blue-team
+- Austrian Business Cycle Monitor: transparent macro research dashboard with visible source health and methodology — /labs/austrian-monitor
 - Source portfolio: multilingual, accessible portfolio with security and delivery checks — https://github.com/JimBLogic/jimblogic.github.io
 
 ## Skills and positioning

--- a/scripts/validate-static.mjs
+++ b/scripts/validate-static.mjs
@@ -4,6 +4,8 @@ import { readFile, stat } from "node:fs/promises";
 const required = [
   "out/index.html",
   "out/certifications/index.html",
+  "out/labs/cyberdailylog/index.html",
+  "out/labs/austrian-monitor/index.html",
   "out/robots.txt",
   "out/sitemap.xml",
   "out/manifest.webmanifest",
@@ -14,9 +16,11 @@ const required = [
 
 await Promise.all(required.map((path) => stat(path)));
 
-const [home, certifications, robots, sitemap] = await Promise.all([
+const [home, certifications, cyberDailyLog, austrianMonitor, robots, sitemap] = await Promise.all([
   readFile("out/index.html", "utf8"),
   readFile("out/certifications/index.html", "utf8"),
+  readFile("out/labs/cyberdailylog/index.html", "utf8"),
+  readFile("out/labs/austrian-monitor/index.html", "utf8"),
   readFile("out/robots.txt", "utf8"),
   readFile("out/sitemap.xml", "utf8"),
 ]);
@@ -26,7 +30,13 @@ assert.match(home, /ProfilePage/);
 assert.match(home, /SoftwareSourceCode/);
 assert.match(home, /https:\/\/jimblogic\.github\.io/);
 assert.match(certifications, /Credentials, without the badge wall/);
+assert.match(cyberDailyLog, /View the complete live application/);
+assert.match(cyberDailyLog, /cyberdailylog-dashboard\.jimblogic\.chatgpt\.site/);
+assert.match(austrianMonitor, /Austrian Business Cycle Monitor/);
+assert.match(austrianMonitor, /austrian-business-cycle-monitor\.jimblogic\.chatgpt\.site/);
 assert.match(robots, /Sitemap: https:\/\/jimblogic\.github\.io\/sitemap\.xml/);
 assert.match(sitemap, /https:\/\/jimblogic\.github\.io\/certifications/);
+assert.match(sitemap, /https:\/\/jimblogic\.github\.io\/labs\/cyberdailylog/);
+assert.match(sitemap, /https:\/\/jimblogic\.github\.io\/labs\/austrian-monitor/);
 
 console.log(`Validated ${required.length} static deployment artifacts.`);


### PR DESCRIPTION
## What changed

- mirrors the current CyberDailyLog and Austrian Business Cycle Monitor project briefs
- keeps the primary live-app calls to action and cross-project navigation aligned with Sites
- adds the Austrian Monitor card and internal brief links to the portfolio
- documents GitHub Pages, ChatGPT Sites, and Docker/Nginx as compatible delivery paths
- adds a reproducible compatibility command and validates both lab routes in the static artifact
- adds the lab routes to the sitemap and `llms.txt`

## Why

The public GitHub source had fallen behind the current Sites interface. This change makes GitHub the reproducible portable source while keeping platform-specific adapters separate.

## Validation

- `npm run verify:mirror`
- static export generated all portfolio, certification, and lab routes
- lint, TypeScript, route artifact, sitemap, document, and live-link checks passed
